### PR TITLE
Monad transformer

### DIFF
--- a/Text/Megaparsec.hs
+++ b/Text/Megaparsec.hs
@@ -48,10 +48,6 @@ module Text.Megaparsec
   , parse
   , parse'
   , parseTest
-    -- * Backtracking user state
-  , getState
-  , setState
-  , modifyState
     -- * Combinators
   , (A.<|>)
   -- $assocbo

--- a/Text/Megaparsec.hs
+++ b/Text/Megaparsec.hs
@@ -31,8 +31,8 @@
 -- > -- import Text.Megaparsec.Text.Lazy
 --
 -- As you can see the second import depends on data type you want to use as
--- input stream. It just defines useful type-synonyms @Parser@ and
--- @GenParser@ and @parseFromFile@ function.
+-- input stream. It just defines useful type-synonym @Parser@ and
+-- @parseFromFile@ function.
 --
 -- Megaparsec is capable of a lot. Apart from this standard functionality
 -- you can parse permutation phrases with "Text.Megaparsec.Perm" and even

--- a/Text/Megaparsec/ByteString.hs
+++ b/Text/Megaparsec/ByteString.hs
@@ -12,7 +12,6 @@
 
 module Text.Megaparsec.ByteString
   ( Parser
-  , GenParser
   , parseFromFile )
 where
 
@@ -27,11 +26,6 @@ import qualified Data.ByteString.Char8 as C
 -- modules”. This one is for strict bytestrings.
 
 type Parser = Parsec C.ByteString
-
--- | @GenParser@ is similar to @Parser@ but it's parametrized over user
--- state type.
-
-type GenParser t st = Parsec C.ByteString st
 
 -- | @parseFromFile p filePath@ runs a strict bytestring parser @p@ on the
 -- input read from @filePath@ using 'ByteString.Char8.readFile'. Returns

--- a/Text/Megaparsec/ByteString.hs
+++ b/Text/Megaparsec/ByteString.hs
@@ -26,7 +26,7 @@ import qualified Data.ByteString.Char8 as C
 -- @Parser@ type and easily change it by importing different “type
 -- modules”. This one is for strict bytestrings.
 
-type Parser = Parsec C.ByteString ()
+type Parser = Parsec C.ByteString
 
 -- | @GenParser@ is similar to @Parser@ but it's parametrized over user
 -- state type.
@@ -44,4 +44,4 @@ type GenParser t st = Parsec C.ByteString st
 -- >     Right xs -> print (sum xs)
 
 parseFromFile :: Parser a -> String -> IO (Either ParseError a)
-parseFromFile p fname = runParser p () fname <$> C.readFile fname
+parseFromFile p fname = runParser p fname <$> C.readFile fname

--- a/Text/Megaparsec/ByteString/Lazy.hs
+++ b/Text/Megaparsec/ByteString/Lazy.hs
@@ -12,7 +12,6 @@
 
 module Text.Megaparsec.ByteString.Lazy
   ( Parser
-  , GenParser
   , parseFromFile )
 where
 
@@ -27,11 +26,6 @@ import qualified Data.ByteString.Lazy.Char8 as C
 -- modules”. This one is for lazy bytestrings.
 
 type Parser = Parsec C.ByteString
-
--- | @GenParser@ is similar to @Parser@ but it's parametrized over user
--- state type.
-
-type GenParser t st = Parsec C.ByteString st
 
 -- | @parseFromFile p filePath@ runs a lazy bytestring parser @p@ on the
 -- input read from @filePath@ using 'ByteString.Lazy.Char8.readFile'.

--- a/Text/Megaparsec/ByteString/Lazy.hs
+++ b/Text/Megaparsec/ByteString/Lazy.hs
@@ -26,7 +26,7 @@ import qualified Data.ByteString.Lazy.Char8 as C
 -- @Parser@ type and easily change it by importing different “type
 -- modules”. This one is for lazy bytestrings.
 
-type Parser = Parsec C.ByteString ()
+type Parser = Parsec C.ByteString
 
 -- | @GenParser@ is similar to @Parser@ but it's parametrized over user
 -- state type.
@@ -44,4 +44,4 @@ type GenParser t st = Parsec C.ByteString st
 -- >     Right xs -> print (sum xs)
 
 parseFromFile :: Parser a -> String -> IO (Either ParseError a)
-parseFromFile p fname = runParser p () fname <$> C.readFile fname
+parseFromFile p fname = runParser p fname <$> C.readFile fname

--- a/Text/Megaparsec/Char.hs
+++ b/Text/Megaparsec/Char.hs
@@ -65,13 +65,13 @@ import Text.Megaparsec.ShowToken
 
 -- | Parses a newline character.
 
-newline :: Stream s m Char => ParsecT s u m Char
+newline :: MonadParsec s m Char => m Char
 newline = char '\n' <?> "newline"
 
 -- | Parses a carriage return character followed by a newline
 -- character. Returns sequence of characters parsed.
 
-crlf :: Stream s m Char => ParsecT s u m String
+crlf :: MonadParsec s m Char => m String
 crlf = string "\r\n"
 
 -- | Parses a CRLF (see 'crlf') or LF (see 'newline') end of line.
@@ -79,49 +79,49 @@ crlf = string "\r\n"
 --
 -- > eol = (pure <$> newline) <|> crlf
 
-eol :: Stream s m Char => ParsecT s u m String
+eol :: MonadParsec s m Char => m String
 eol = (pure <$> newline) <|> crlf <?> "end of line"
 
 -- | Parses a tab character.
 
-tab :: Stream s m Char => ParsecT s u m Char
+tab :: MonadParsec s m Char => m Char
 tab = char '\t' <?> "tab"
 
 -- | Skips /zero/ or more white space characters. See also 'skipMany' and
 -- 'spaceChar'.
 
-space :: Stream s m Char => ParsecT s u m ()
+space :: MonadParsec s m Char => m ()
 space = skipMany spaceChar
 
 -- | Parses control characters, which are the non-printing characters of the
 -- Latin-1 subset of Unicode.
 
-controlChar :: Stream s m Char => ParsecT s u m Char
+controlChar :: MonadParsec s m Char => m Char
 controlChar = satisfy isControl <?> "control character"
 
 -- | Parses a Unicode space character, and the control characters: tab,
 -- newline, carriage return, form feed, and vertical tab.
 
-spaceChar :: Stream s m Char => ParsecT s u m Char
+spaceChar :: MonadParsec s m Char => m Char
 spaceChar = satisfy isSpace <?> "white space"
 
 -- | Parses an upper-case or title-case alphabetic Unicode character. Title
 -- case is used by a small number of letter ligatures like the
 -- single-character form of Lj.
 
-upperChar :: Stream s m Char => ParsecT s u m Char
+upperChar :: MonadParsec s m Char => m Char
 upperChar = satisfy isUpper <?> "uppercase letter"
 
 -- | Parses a lower-case alphabetic Unicode character.
 
-lowerChar :: Stream s m Char => ParsecT s u m Char
+lowerChar :: MonadParsec s m Char => m Char
 lowerChar = satisfy isLower <?> "lowercase letter"
 
 -- | Parses alphabetic Unicode characters: lower-case, upper-case and
 -- title-case letters, plus letters of case-less scripts and modifiers
 -- letters.
 
-letterChar :: Stream s m Char => ParsecT s u m Char
+letterChar :: MonadParsec s m Char => m Char
 letterChar = satisfy isLetter <?> "letter"
 
 -- | Parses alphabetic or numeric digit Unicode characters.
@@ -130,76 +130,76 @@ letterChar = satisfy isLetter <?> "letter"
 -- parser but not by 'digitChar'. Such digits may be part of identifiers but
 -- are not used by the printer and reader to represent numbers.
 
-alphaNumChar :: Stream s m Char => ParsecT s u m Char
+alphaNumChar :: MonadParsec s m Char => m Char
 alphaNumChar = satisfy isAlphaNum <?> "alphanumeric character"
 
 -- | Parses printable Unicode characters: letters, numbers, marks,
 -- punctuation, symbols and spaces.
 
-printChar :: Stream s m Char => ParsecT s u m Char
+printChar :: MonadParsec s m Char => m Char
 printChar = satisfy isPrint <?> "printable character"
 
 -- | Parses an ASCII digit, i.e between “0” and “9”.
 
-digitChar :: Stream s m Char => ParsecT s u m Char
+digitChar :: MonadParsec s m Char => m Char
 digitChar = satisfy isDigit <?> "digit"
 
 -- | Parses an octal digit, i.e. between “0” and “7”.
 
-octDigitChar :: Stream s m Char => ParsecT s u m Char
+octDigitChar :: MonadParsec s m Char => m Char
 octDigitChar = satisfy isOctDigit <?> "octal digit"
 
 -- | Parses a hexadecimal digit, i.e. between “0” and “9”, or “a” and “f”,
 -- or “A” and “F”.
 
-hexDigitChar :: Stream s m Char => ParsecT s u m Char
+hexDigitChar :: MonadParsec s m Char => m Char
 hexDigitChar = satisfy isHexDigit <?> "hexadecimal digit"
 
 -- | Parses Unicode mark characters, for example accents and the like, which
 -- combine with preceding characters.
 
-markChar :: Stream s m Char => ParsecT s u m Char
+markChar :: MonadParsec s m Char => m Char
 markChar = satisfy isMark <?> "mark character"
 
 -- | Parses Unicode numeric characters, including digits from various
 -- scripts, Roman numerals, et cetera.
 
-numberChar :: Stream s m Char => ParsecT s u m Char
+numberChar :: MonadParsec s m Char => m Char
 numberChar = satisfy isNumber <?> "numeric character"
 
 -- | Parses Unicode punctuation characters, including various kinds of
 -- connectors, brackets and quotes.
 
-punctuationChar :: Stream s m Char => ParsecT s u m Char
+punctuationChar :: MonadParsec s m Char => m Char
 punctuationChar = satisfy isPunctuation <?> "punctuation"
 
 -- | Parses Unicode symbol characters, including mathematical and currency
 -- symbols.
 
-symbolChar :: Stream s m Char => ParsecT s u m Char
+symbolChar :: MonadParsec s m Char => m Char
 symbolChar = satisfy isSymbol <?> "symbol"
 
 -- | Parses Unicode space and separator characters.
 
-separatorChar :: Stream s m Char => ParsecT s u m Char
+separatorChar :: MonadParsec s m Char => m Char
 separatorChar = satisfy isSeparator <?> "separator"
 
 -- | Parses a character from the first 128 characters of the Unicode character set,
 -- corresponding to the ASCII character set.
 
-asciiChar :: Stream s m Char => ParsecT s u m Char
+asciiChar :: MonadParsec s m Char => m Char
 asciiChar = satisfy isAscii <?> "ASCII character"
 
 -- | Parses a character from the first 256 characters of the Unicode
 -- character set, corresponding to the ISO 8859-1 (Latin-1) character set.
 
-latin1Char :: Stream s m Char => ParsecT s u m Char
+latin1Char :: MonadParsec s m Char => m Char
 latin1Char = satisfy isLatin1 <?> "Latin-1 character"
 
 -- | @charCategory cat@ Parses character in Unicode General Category @cat@,
 -- see 'Data.Char.GeneralCategory'.
 
-charCategory :: Stream s m Char => GeneralCategory -> ParsecT s u m Char
+charCategory :: MonadParsec s m Char => GeneralCategory -> m Char
 charCategory cat = satisfy ((== cat) . generalCategory) <?> categoryName cat
 
 -- | Returns human-readable name of Unicode General Category.
@@ -242,7 +242,7 @@ categoryName cat =
 --
 -- > semicolon = char ';'
 
-char :: Stream s m Char => Char -> ParsecT s u m Char
+char :: MonadParsec s m Char => Char -> m Char
 char c = satisfy (== c) <?> showToken c
 
 -- | The same as 'char' but case-insensitive. This parser returns actually
@@ -255,7 +255,7 @@ char c = satisfy (== c) <?> showToken c
 -- unexpected 'G'
 -- expecting 'E' or 'e'
 
-char' :: Stream s m Char => Char -> ParsecT s u m Char
+char' :: MonadParsec s m Char => Char -> m Char
 char' = choice . fmap char . extendi . pure
 
 -- | Extends given list of characters adding uppercase version of every
@@ -270,7 +270,7 @@ extendi cs = nub (cs >>= f)
 
 -- | This parser succeeds for any character. Returns the parsed character.
 
-anyChar :: Stream s m Char => ParsecT s u m Char
+anyChar :: MonadParsec s m Char => m Char
 anyChar = satisfy (const True) <?> "character"
 
 -- | @oneOf cs@ succeeds if the current character is in the supplied
@@ -283,7 +283,7 @@ anyChar = satisfy (const True) <?> "character"
 --
 -- > digit = oneOf ['0'..'9'] <?> "digit"
 
-oneOf :: Stream s m Char => String -> ParsecT s u m Char
+oneOf :: MonadParsec s m Char => String -> m Char
 oneOf cs = satisfy (`elem` cs)
 
 -- | The same as 'oneOf', but case-insensitive. Returns the parsed character
@@ -291,21 +291,21 @@ oneOf cs = satisfy (`elem` cs)
 --
 -- > vowel = oneOf' "aeiou" <?> "vowel"
 
-oneOf' :: Stream s m Char => String -> ParsecT s u m Char
+oneOf' :: MonadParsec s m Char => String -> m Char
 oneOf' = oneOf . extendi
 
 -- | As the dual of 'oneOf', @noneOf cs@ succeeds if the current
 -- character /not/ in the supplied list of characters @cs@. Returns the
 -- parsed character.
 
-noneOf :: Stream s m Char => String -> ParsecT s u m Char
+noneOf :: MonadParsec s m Char => String -> m Char
 noneOf cs = satisfy (`notElem` cs)
 
 -- | The same as 'noneOf', but case-insensitive.
 --
 -- > consonant = noneOf' "aeiou" <?> "consonant"
 
-noneOf' :: Stream s m Char => String -> ParsecT s u m Char
+noneOf' :: MonadParsec s m Char => String -> m Char
 noneOf' = noneOf . extendi
 
 -- | The parser @satisfy f@ succeeds for any character for which the
@@ -315,7 +315,7 @@ noneOf' = noneOf . extendi
 -- > digitChar = satisfy isDigit <?> "digit"
 -- > oneOf cs  = satisfy (`elem` cs)
 
-satisfy :: Stream s m Char => (Char -> Bool) -> ParsecT s u m Char
+satisfy :: MonadParsec s m Char => (Char -> Bool) -> m Char
 satisfy f = token nextPos testChar
   where nextPos pos x _ = updatePosChar pos x
         testChar x      = if f x
@@ -327,7 +327,7 @@ satisfy f = token nextPos testChar
 --
 -- > divOrMod = string "div" <|> string "mod"
 
-string :: Stream s m Char => String -> ParsecT s u m String
+string :: MonadParsec s m Char => String -> m String
 string = tokens updatePosString (==)
 
 -- | The same as 'string', but case-insensitive. On success returns string
@@ -336,6 +336,6 @@ string = tokens updatePosString (==)
 -- >>> parseTest (string' "foobar") "foObAr"
 -- "foobar"
 
-string' :: Stream s m Char => String -> ParsecT s u m String
+string' :: MonadParsec s m Char => String -> m String
 string' = tokens updatePosString test
   where test x y = toLower x == toLower y

--- a/Text/Megaparsec/Perm.hs
+++ b/Text/Megaparsec/Perm.hs
@@ -23,25 +23,24 @@ module Text.Megaparsec.Perm
   , (<|?>) )
 where
 
-import Control.Monad.Identity
-
 import Text.Megaparsec.Combinator (choice)
 import Text.Megaparsec.Prim
 
 infixl 1 <||>, <|?>
 infixl 2 <$$>, <$?>
 
--- | The type @PermParser s u a@ denotes a permutation parser that,
--- when converted by the 'makePermParser' function, parses @s@ stream with
--- user state @u@ and returns a value of type @a@ on success.
+-- | The type @PermParser s m a@ denotes a permutation parser that,
+-- when converted by the 'makePermParser' function, produces instance of
+-- 'MonadParsec' @m@ that parses @s@ stream and returns a value of type @a@
+-- on success.
 --
 -- Normally, a permutation parser is first build with special operators like
 -- ('<||>') and than transformed into a normal parser using
 -- 'makePermParser'.
 
-data PermParser s u a = Perm (Maybe a) [Branch s u a]
+data PermParser s m a = Perm (Maybe a) [Branch s m a]
 
-data Branch s u a = forall b. Branch (PermParser s u (b -> a)) (Parsec s u b)
+data Branch s m a = forall b. Branch (PermParser s m (b -> a)) (m b)
 
 -- | The parser @makePermParser perm@ parses a permutation of parser described
 -- by @perm@. For example, suppose we want to parse a permutation of: an
@@ -53,7 +52,7 @@ data Branch s u a = forall b. Branch (PermParser s u (b -> a)) (Parsec s u b)
 -- >               <||> char 'b'
 -- >               <|?> ('_', char 'c')
 
-makePermParser :: Stream s Identity t => PermParser s u a -> Parsec s u a
+makePermParser :: MonadParsec s m t => PermParser s m a -> m a
 makePermParser (Perm def xs) = choice (fmap branch xs ++ empty)
   where empty = case def of
                   Nothing -> []
@@ -73,7 +72,7 @@ makePermParser (Perm def xs) = choice (fmap branch xs ++ empty)
 -- by the parsers. The function @f@ gets its parameters in the order in
 -- which the parsers are specified, but actual input can be in any order.
 
-(<$$>) :: Stream s Identity t => (a -> b) -> Parsec s u a -> PermParser s u b
+(<$$>) :: MonadParsec s m t => (a -> b) -> m a -> PermParser s m b
 f <$$> p = newperm f <||> p
 
 -- | The expression @f \<$?> (x, p)@ creates a fresh permutation parser
@@ -82,8 +81,7 @@ f <$$> p = newperm f <||> p
 -- optional — if it cannot be applied, the default value @x@ will be used
 -- instead.
 
-(<$?>) :: Stream s Identity t =>
-          (a -> b) -> (a, Parsec s u a) -> PermParser s u b
+(<$?>) :: MonadParsec s m t => (a -> b) -> (a, m a) -> PermParser s m b
 f <$?> xp = newperm f <|?> xp
 
 -- | The expression @perm \<||> p@ adds parser @p@ to the permutation
@@ -91,8 +89,8 @@ f <$?> xp = newperm f <|?> xp
 -- the optional combinator ('<|?>') instead. Returns a new permutation
 -- parser that includes @p@.
 
-(<||>) :: Stream s Identity t =>
-          PermParser s u (a -> b) -> Parsec s u a -> PermParser s u b
+(<||>) :: MonadParsec s m t =>
+          PermParser s m (a -> b) -> m a -> PermParser s m b
 (<||>) = add
 
 -- | The expression @perm \<||> (x, p)@ adds parser @p@ to the
@@ -100,26 +98,25 @@ f <$?> xp = newperm f <|?> xp
 -- applied, the default value @x@ will be used instead. Returns a new
 -- permutation parser that includes the optional parser @p@.
 
-(<|?>) :: Stream s Identity t =>
-          PermParser s u (a -> b) -> (a, Parsec s u a) -> PermParser s u b
+(<|?>) :: MonadParsec s m t =>
+          PermParser s m (a -> b) -> (a, m a) -> PermParser s m b
 perm <|?> (x, p) = addopt perm x p
 
-newperm :: Stream s Identity t => (a -> b) -> PermParser s u (a -> b)
+newperm :: MonadParsec s m t => (a -> b) -> PermParser s m (a -> b)
 newperm f = Perm (Just f) []
 
-add :: Stream s Identity t =>
-       PermParser s u (a -> b) -> Parsec s u a -> PermParser s u b
+add :: MonadParsec s m t => PermParser s m (a -> b) -> m a -> PermParser s m b
 add perm@(Perm _mf fs) p = Perm Nothing (first : fmap insert fs)
   where first = Branch perm p
         insert (Branch perm' p') = Branch (add (mapPerms flip perm') p) p'
 
-addopt :: Stream s Identity t =>
-          PermParser s u (a -> b) -> a -> Parsec s u a -> PermParser s u b
+addopt :: MonadParsec s m t =>
+          PermParser s m (a -> b) -> a -> m a -> PermParser s m b
 addopt perm@(Perm mf fs) x p = Perm (fmap ($ x) mf) (first : fmap insert fs)
   where first   = Branch perm p
         insert (Branch perm' p') = Branch (addopt (mapPerms flip perm') x p) p'
 
-mapPerms :: Stream s Identity t =>
-            (a -> b) -> PermParser s u a -> PermParser s u b
+mapPerms :: MonadParsec s m t =>
+            (a -> b) -> PermParser s m a -> PermParser s m b
 mapPerms f (Perm x xs) = Perm (fmap f x) (fmap mapBranch xs)
   where mapBranch (Branch perm p) = Branch (mapPerms (f .) perm) p

--- a/Text/Megaparsec/Prim.hs
+++ b/Text/Megaparsec/Prim.hs
@@ -68,13 +68,6 @@ data State s = State
 
 -- | An instance of @Stream s t@ has stream type @s@, and token type @t@
 -- determined by the stream.
---
--- Some rough guidelines for a “correct” instance of Stream:
---
---     * @unfoldM uncons@ gives the @[t]@ corresponding to the stream.
---     * A @Stream@ instance is responsible for maintaining the “position
---       within the stream” in the stream state @s@. This is trivial unless
---       you are using the monad in a non-trivial way.
 
 class (ShowToken t, ShowToken [t]) => Stream s t | s -> t where
   uncons :: s -> Maybe (t, s)

--- a/Text/Megaparsec/String.hs
+++ b/Text/Megaparsec/String.hs
@@ -24,7 +24,7 @@ import Text.Megaparsec.Prim
 -- @Parser@ type and easily change it by importing different “type
 -- modules”. This one is for strings.
 
-type Parser = Parsec String ()
+type Parser = Parsec String
 
 -- | @GenParser@ is similar to @Parser@ but it's parametrized over user
 -- state type.
@@ -42,4 +42,4 @@ type GenParser tok st = Parsec [tok] st
 -- >     Right xs -> print (sum xs)
 
 parseFromFile :: Parser a -> String -> IO (Either ParseError a)
-parseFromFile p fname = runParser p () fname <$> readFile fname
+parseFromFile p fname = runParser p fname <$> readFile fname

--- a/Text/Megaparsec/String.hs
+++ b/Text/Megaparsec/String.hs
@@ -12,7 +12,6 @@
 
 module Text.Megaparsec.String
   ( Parser
-  , GenParser
   , parseFromFile )
 where
 
@@ -25,11 +24,6 @@ import Text.Megaparsec.Prim
 -- modules”. This one is for strings.
 
 type Parser = Parsec String
-
--- | @GenParser@ is similar to @Parser@ but it's parametrized over user
--- state type.
-
-type GenParser tok st = Parsec [tok] st
 
 -- | @parseFromFile p filePath@ runs a string parser @p@ on the
 -- input read from @filePath@ using 'Prelude.readFile'. Returns either a

--- a/Text/Megaparsec/Text.hs
+++ b/Text/Megaparsec/Text.hs
@@ -26,7 +26,7 @@ import qualified Data.Text.IO as T
 -- @Parser@ type and easily change it by importing different “type
 -- modules”. This one is for strict text.
 
-type Parser = Parsec T.Text ()
+type Parser = Parsec T.Text
 
 -- | @GenParser@ is similar to @Parser@ but it's parametrized over user
 -- state type.
@@ -44,4 +44,4 @@ type GenParser st = Parsec T.Text st
 -- >     Right xs -> print (sum xs)
 
 parseFromFile :: Parser a -> String -> IO (Either ParseError a)
-parseFromFile p fname = runParser p () fname <$> T.readFile fname
+parseFromFile p fname = runParser p fname <$> T.readFile fname

--- a/Text/Megaparsec/Text.hs
+++ b/Text/Megaparsec/Text.hs
@@ -12,7 +12,6 @@
 
 module Text.Megaparsec.Text
   ( Parser
-  , GenParser
   , parseFromFile )
 where
 
@@ -27,11 +26,6 @@ import qualified Data.Text.IO as T
 -- modules”. This one is for strict text.
 
 type Parser = Parsec T.Text
-
--- | @GenParser@ is similar to @Parser@ but it's parametrized over user
--- state type.
-
-type GenParser st = Parsec T.Text st
 
 -- | @parseFromFile p filePath@ runs a lazy text parser @p@ on the
 -- input read from @filePath@ using 'Data.Text.IO.readFile'. Returns either

--- a/Text/Megaparsec/Text/Lazy.hs
+++ b/Text/Megaparsec/Text/Lazy.hs
@@ -12,7 +12,6 @@
 
 module Text.Megaparsec.Text.Lazy
   ( Parser
-  , GenParser
   , parseFromFile )
 where
 
@@ -27,11 +26,6 @@ import qualified Data.Text.Lazy.IO as T
 -- modules”. This one is for lazy text.
 
 type Parser = Parsec T.Text
-
--- | @GenParser@ is similar to @Parser@ but it's parametrized over user
--- state type.
-
-type GenParser st = Parsec T.Text st
 
 -- | @parseFromFile p filePath@ runs a lazy text parser @p@ on the
 -- input read from @filePath@ using 'Data.Text.Lazy.IO.readFile'. Returns

--- a/Text/Megaparsec/Text/Lazy.hs
+++ b/Text/Megaparsec/Text/Lazy.hs
@@ -26,7 +26,7 @@ import qualified Data.Text.Lazy.IO as T
 -- @Parser@ type and easily change it by importing different “type
 -- modules”. This one is for lazy text.
 
-type Parser = Parsec T.Text ()
+type Parser = Parsec T.Text
 
 -- | @GenParser@ is similar to @Parser@ but it's parametrized over user
 -- state type.
@@ -44,4 +44,4 @@ type GenParser st = Parsec T.Text st
 -- >     Right xs -> print (sum xs)
 
 parseFromFile :: Parser a -> String -> IO (Either ParseError a)
-parseFromFile p fname = runParser p () fname <$> T.readFile fname
+parseFromFile p fname = runParser p fname <$> T.readFile fname

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -81,6 +81,7 @@ extra-source-files:  AUTHORS.md, CHANGELOG.md
 library
   build-depends:     base                   >= 4.8 && < 5
                    , mtl
+                   , transformers           == 0.4.*
                    , bytestring
                    , text                   >= 0.2 && < 1.3
   default-extensions:

--- a/old-tests/Bugs/Bug9.hs
+++ b/old-tests/Bugs/Bug9.hs
@@ -27,16 +27,16 @@ main =
 
 -- Syntax analysis
 
-sc :: Stream s m Char => ParsecT s u m ()
+sc :: Parser ()
 sc = L.space (void spaceChar) empty empty
 
-lexeme :: Stream s m Char => ParsecT s u m a -> ParsecT s u m a
+lexeme :: Parser a -> Parser a
 lexeme = L.lexeme sc
 
-integer :: Stream s m Char => ParsecT s u m Integer
+integer :: Parser Integer
 integer = lexeme L.integer
 
-operator :: Stream s m Char => String -> ParsecT s u m String
+operator :: String -> Parser String
 operator = try . L.symbol sc
 
 parseTopLevel :: Parser Expr

--- a/tests/Expr.hs
+++ b/tests/Expr.hs
@@ -121,16 +121,16 @@ arbitraryN2 n = elements [Sum,Sub,Pro,Div,Exp] <*> leaf <*> leaf
 -- Some helpers put here since we don't want to depend on
 -- "Text.Megaparsec.Lexer".
 
-lexeme :: Stream s m Char => ParsecT s u m a -> ParsecT s u m a
+lexeme :: MonadParsec s m Char => m a -> m a
 lexeme p = p <* hidden space
 
-symbol :: Stream s m Char => String -> ParsecT s u m String
+symbol :: MonadParsec s m Char => String -> m String
 symbol = lexeme . string
 
-parens :: Stream s m Char => ParsecT s u m a -> ParsecT s u m a
+parens :: MonadParsec s m Char => m a -> m a
 parens = between (symbol "(") (symbol ")")
 
-integer :: Stream s m Char => ParsecT s u m Integer
+integer :: MonadParsec s m Char => m Integer
 integer = lexeme (read <$> some digitChar <?> "integer")
 
 -- Here we use table of operators that makes use of all features of
@@ -138,13 +138,13 @@ integer = lexeme (read <$> some digitChar <?> "integer")
 -- but valid expressions and render them to get their textual
 -- representation.
 
-expr :: Stream s m Char => ParsecT s u m Node
+expr :: MonadParsec s m Char => m Node
 expr = makeExprParser term table <?> "expression"
 
-term :: Stream s m Char => ParsecT s u m Node
+term :: MonadParsec s m Char => m Node
 term = parens expr <|> (Val <$> integer) <?> "term"
 
-table :: Stream s m Char => [[Operator s u m Node]]
+table :: MonadParsec s m Char => [[Operator m Node]]
 table = [ [ Prefix  (symbol "-" *> pure Neg)
           , Postfix (symbol "!" *> pure Fac)
           , InfixN  (symbol "%" *> pure Mod) ]


### PR DESCRIPTION
This branch contains various changes made according to issue #27.

The changes include:

* elimination of built-in backtracking user state

* introduction of type class `MonadParsec` and corrections in type signatures of most tools to work smoothly with any instance of `MonadParsec`, not only `ParsecT`.

Criticism and practical testing are welcome.