### PR TITLE
Add some tests for monad transformers (see #27)

### DIFF
--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -139,6 +139,8 @@ test-suite tests
   ghc-options:       -O2 -Wall -rtsopts
   build-depends:     base                   >= 4.8 && < 5
                    , megaparsec             >= 4.0.0
+                   , mtl                    == 2.*
+                   , transformers           == 0.4.*
                    , QuickCheck             >= 2.4 && < 3
                    , test-framework         >= 0.6 && < 1
                    , test-framework-quickcheck2 >= 0.3 && < 0.4


### PR DESCRIPTION
This brings coverage to 82%; it could be made even higher by replicating more tests for `ReaderT` and `IdentityT`, but it feels like... cheating? Also I can't think of any non-trivial tests for `getParserState` and `updateParserState` that would be related to `StateT`.