### PR TITLE
Add compatibility to GHC 7.8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,11 @@ Megaparsec is different from Parsec in the following ways:
 * Megaparsec's code is clearer and doesn't contain “magic” found in original
   Parsec.
 
-* Megaparsec looks into the future, it does not contain code that serves for
-  compatibility purposes, it also requires more recent version of `base`.
-
 ## Megaparsec vs Parsec
 
 There are good reasons to use Parsec:
 
-* You need to work with legacy code or with older versions of GHC (< 7.10).
+* You need to work with legacy code or with older versions of GHC (< 7.8).
 
 And that's it. In other cases you should prefer Megaparsec for your own
 sake. If you think you have a reason to use Parsec other than listed here,

--- a/Text/Megaparsec/ByteString.hs
+++ b/Text/Megaparsec/ByteString.hs
@@ -38,4 +38,4 @@ type Parser = Parsec C.ByteString
 -- >     Right xs -> print (sum xs)
 
 parseFromFile :: Parser a -> String -> IO (Either ParseError a)
-parseFromFile p fname = runParser p fname <$> C.readFile fname
+parseFromFile p fname = runParser p fname `fmap` C.readFile fname

--- a/Text/Megaparsec/ByteString/Lazy.hs
+++ b/Text/Megaparsec/ByteString/Lazy.hs
@@ -38,4 +38,4 @@ type Parser = Parsec C.ByteString
 -- >     Right xs -> print (sum xs)
 
 parseFromFile :: Parser a -> String -> IO (Either ParseError a)
-parseFromFile p fname = runParser p fname <$> C.readFile fname
+parseFromFile p fname = runParser p fname `fmap` C.readFile fname

--- a/Text/Megaparsec/Char.hs
+++ b/Text/Megaparsec/Char.hs
@@ -63,6 +63,10 @@ import Text.Megaparsec.Pos
 import Text.Megaparsec.Prim
 import Text.Megaparsec.ShowToken
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), pure)
+#endif
+
 -- | Parses a newline character.
 
 newline :: MonadParsec s m Char => m Char

--- a/Text/Megaparsec/Combinator.hs
+++ b/Text/Megaparsec/Combinator.hs
@@ -39,6 +39,10 @@ import Control.Applicative
 import Control.Monad (void)
 import Data.Foldable (asum)
 
+#if !MIN_VERSION_base(4,8,0)
+import Data.Foldable (Foldable)
+#endif
+
 -- | @between open close p@ parses @open@, followed by @p@ and @close@.
 -- Returns the value returned by @p@.
 --

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -34,6 +34,11 @@ import Data.Maybe (fromMaybe)
 
 import Text.Megaparsec.Pos
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>))
+import Data.Foldable (foldMap)
+#endif
+
 -- | This data type represents parse error messages. There are three kinds
 -- of messages:
 --

--- a/Text/Megaparsec/Lexer.hs
+++ b/Text/Megaparsec/Lexer.hs
@@ -50,6 +50,10 @@ import Text.Megaparsec.Prim
 import Text.Megaparsec.ShowToken
 import qualified Text.Megaparsec.Char as C
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*), (*>), (<*>), pure)
+#endif
+
 -- White space and indentation
 
 -- | @space spaceChar lineComment blockComment@ produces parser that can

--- a/Text/Megaparsec/Perm.hs
+++ b/Text/Megaparsec/Perm.hs
@@ -28,6 +28,10 @@ where
 import Text.Megaparsec.Combinator (choice)
 import Text.Megaparsec.Prim
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*>))
+#endif
+
 infixl 1 <||>, <|?>
 infixl 2 <$$>, <$?>
 

--- a/Text/Megaparsec/Prim.hs
+++ b/Text/Megaparsec/Prim.hs
@@ -67,6 +67,10 @@ import Text.Megaparsec.Error
 import Text.Megaparsec.Pos
 import Text.Megaparsec.ShowToken
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*))
+#endif
+
 -- | This is Megaparsec state, it's parametrized over stream type @s@.
 
 data State s = State

--- a/Text/Megaparsec/String.hs
+++ b/Text/Megaparsec/String.hs
@@ -36,4 +36,4 @@ type Parser = Parsec String
 -- >     Right xs -> print (sum xs)
 
 parseFromFile :: Parser a -> String -> IO (Either ParseError a)
-parseFromFile p fname = runParser p fname <$> readFile fname
+parseFromFile p fname = runParser p fname `fmap` readFile fname

--- a/Text/Megaparsec/Text.hs
+++ b/Text/Megaparsec/Text.hs
@@ -38,4 +38,4 @@ type Parser = Parsec T.Text
 -- >     Right xs -> print (sum xs)
 
 parseFromFile :: Parser a -> String -> IO (Either ParseError a)
-parseFromFile p fname = runParser p fname <$> T.readFile fname
+parseFromFile p fname = runParser p fname `fmap` T.readFile fname

--- a/Text/Megaparsec/Text/Lazy.hs
+++ b/Text/Megaparsec/Text/Lazy.hs
@@ -38,4 +38,4 @@ type Parser = Parsec T.Text
 -- >     Right xs -> print (sum xs)
 
 parseFromFile :: Parser a -> String -> IO (Either ParseError a)
-parseFromFile p fname = runParser p fname <$> T.readFile fname
+parseFromFile p fname = runParser p fname `fmap` T.readFile fname

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -79,13 +79,14 @@ description:
 extra-source-files:  AUTHORS.md, CHANGELOG.md
 
 library
-  build-depends:     base                   >= 4.8 && < 5
+  build-depends:     base                   >= 4.7 && < 5
                    , mtl                    == 2.*
                    , transformers           == 0.4.*
                    , bytestring
                    , text                   >= 0.2 && < 1.3
   default-extensions:
-                     DeriveDataTypeable
+                     CPP
+                   , DeriveDataTypeable
                    , FlexibleContexts
                    , FlexibleInstances
                    , FunctionalDependencies
@@ -124,13 +125,14 @@ test-suite old-tests
                    , Bugs.Bug35
                    , Bugs.Bug39
                    , Util
-  build-depends:     base                   >= 4.8 && < 5
+  build-depends:     base                   >= 4.7 && < 5
                    , megaparsec             >= 4.0.0
                    , HUnit                  >= 1.2 && < 1.4
                    , test-framework         >= 0.6 && < 1
                    , test-framework-hunit   >= 0.2 && < 0.4
   default-extensions:
-                     FlexibleContexts
+                     CPP
+                   , FlexibleContexts
   default-language:  Haskell2010
 
 test-suite tests
@@ -147,7 +149,7 @@ test-suite tests
                    , Pos
                    , Prim
                    , Util
-  build-depends:     base                   >= 4.8 && < 5
+  build-depends:     base                   >= 4.7 && < 5
                    , megaparsec             >= 4.0.0
                    , mtl                    == 2.*
                    , transformers           == 0.4.*
@@ -155,7 +157,8 @@ test-suite tests
                    , test-framework         >= 0.6 && < 1
                    , test-framework-quickcheck2 >= 0.3 && < 0.4
   default-extensions:
-                     FlexibleContexts
+                     CPP
+                   , FlexibleContexts
                    , FlexibleInstances
   default-language:  Haskell2010
 
@@ -164,7 +167,7 @@ benchmark benchmarks
   hs-source-dirs:    benchmarks
   type:              exitcode-stdio-1.0
   ghc-options:       -O2 -Wall -rtsopts
-  build-depends:     base                   >= 4.8 && < 5
+  build-depends:     base                   >= 4.7 && < 5
                    , megaparsec             >= 4.0.0
                    , criterion              >= 0.6.2.1 && < 1.2
                    , text                   >= 1.2 && < 2

--- a/old-tests/Bugs/Bug9.hs
+++ b/old-tests/Bugs/Bug9.hs
@@ -15,6 +15,10 @@ import Test.HUnit hiding (Test)
 
 import Util
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*), (<$))
+#endif
+
 data Expr = Const Integer | Op Expr Expr deriving Show
 
 main :: Test

--- a/tests/Char.hs
+++ b/tests/Char.hs
@@ -42,6 +42,10 @@ import Text.Megaparsec.Char
 
 import Util
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>))
+#endif
+
 tests :: Test
 tests = testGroup "Character parsers"
         [ testProperty "newline"         prop_newline

--- a/tests/Error.hs
+++ b/tests/Error.hs
@@ -42,6 +42,10 @@ import Pos ()
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*>))
+#endif
+
 tests :: Test
 tests = testGroup "Parse errors"
         [ testProperty "extracting message string" prop_messageString

--- a/tests/Expr.hs
+++ b/tests/Expr.hs
@@ -43,6 +43,10 @@ import Text.Megaparsec.Prim
 
 import Util
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*), (<*>), (*>), pure)
+#endif
+
 tests :: Test
 tests = testGroup "Expression parsers"
         [ testProperty "correctness of expression parser" prop_correctness ]

--- a/tests/Lexer.hs
+++ b/tests/Lexer.hs
@@ -56,6 +56,10 @@ import qualified Text.Megaparsec.Char as C
 
 import Util
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*), (<*>))
+#endif
+
 tests :: Test
 tests = testGroup "Lexer"
         [ testProperty "space combinator"            prop_space

--- a/tests/Pos.hs
+++ b/tests/Pos.hs
@@ -40,6 +40,10 @@ import Test.QuickCheck
 
 import Text.Megaparsec.Pos
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*>), pure)
+#endif
+
 tests :: Test
 tests = testGroup "Textual source positions"
         [ testProperty "components" prop_components

--- a/tests/Util.hs
+++ b/tests/Util.hs
@@ -58,6 +58,10 @@ import Text.Megaparsec.Prim
 import Text.Megaparsec.ShowToken
 import Text.Megaparsec.String
 
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>), (<*))
+#endif
+
 -- | @checkParser p r s@ tries to run parser @p@ on input @s@ to parse
 -- entire @s@. Result of the parsing is compared with expected result @r@,
 -- it should match, otherwise the property doesn't hold and the test fails.
@@ -106,7 +110,7 @@ checkString p a' test l s' = checkParser p (w a' 0 s') s'
           | otherwise = posErr 0 s' [uneStr (take i' s'), exSpec l]
             where i'  = succ i
 
-infix 4 /=\
+infix 4 /=\   -- preserve whitespace on automatic trim
 
 -- | @p /=\\ x@ runs parser @p@ on empty input and compares its result
 -- (which should be successful) with @x@. Succeeds when the result is equal


### PR DESCRIPTION
This PR basically introduces a bunch of CPP `#if`s to import additional operators from `Control.Applicative` (in most cases) or `Data.Foldable` (in one case). See #42 for the original issue.

I didn't change the existing `import Control.Applicative` lines, since they would lead to redundant import warnings on GHC 7.10.x, and instead put the `#if MIN_VERSION` makros at the end of all imports in all files. in all files that used only `<$>` in one place, I replaced `<$>` by infix `fmap` to keep the number of changes per file a little bit smaller.

While I was at it, I also removed the "recent version of `base`" comment in the readme, since it works now with an older one (by the way, base-4.6 compatibility seems possible, currently experimenting).

Things left to do:

- [ ] change Travis configuration to automatically check compatibility with 4.7.x

-----

## Remarks

- the fixity declaration of `/=\` in tests/Utils.hs lead to some issues. I've added a comment, which will prevent backslash-before-newline trouble.
- while the current version works, it introduces many changes to many files. The next version of base shouldn't break anything (at least regarding the `Control.Applicative` part), but one should probably think of a less error prone strategy, like a custom prelude (so that there's only a single point of CPP).