### PR TITLE
Add base-4.6.0.x compatiblity

### DIFF
--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -28,7 +28,9 @@ module Text.Megaparsec.Error
   , showMessages )
 where
 
+#if MIN_VERSION_base(4,7,0)
 import Data.Bool (bool)
+#endif
 import Data.List (intercalate)
 import Data.Maybe (fromMaybe)
 
@@ -37,6 +39,11 @@ import Text.Megaparsec.Pos
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))
 import Data.Foldable (foldMap)
+#endif
+#if !MIN_VERSION_base(4,7,0)
+bool :: a -> a -> Bool -> a
+bool f _ False = f
+bool _ t True  = t
 #endif
 
 -- | This data type represents parse error messages. There are three kinds

--- a/Text/Megaparsec/Prim.hs
+++ b/Text/Megaparsec/Prim.hs
@@ -40,7 +40,9 @@ module Text.Megaparsec.Prim
   , parseTest )
 where
 
+#if MIN_VERSION_base(4,7,0)
 import Data.Bool (bool)
+#endif
 import Data.Monoid
 
 import Control.Monad
@@ -69,6 +71,11 @@ import Text.Megaparsec.ShowToken
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>), (<*))
+#endif
+#if !MIN_VERSION_base(4,7,0)
+bool :: a -> a -> Bool -> a
+bool f _ False = f
+bool _ t True  = t
 #endif
 
 -- | This is Megaparsec state, it's parametrized over stream type @s@.

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -76,7 +76,7 @@ description:
 extra-source-files:  AUTHORS.md, CHANGELOG.md
 
 library
-  build-depends:     base                   >= 4.7 && < 5
+  build-depends:     base                   >= 4.6 && < 5
                    , mtl                    == 2.*
                    , transformers           == 0.4.*
                    , bytestring
@@ -122,7 +122,7 @@ test-suite old-tests
                    , Bugs.Bug35
                    , Bugs.Bug39
                    , Util
-  build-depends:     base                   >= 4.7 && < 5
+  build-depends:     base                   >= 4.6 && < 5
                    , megaparsec             >= 4.0.0
                    , HUnit                  >= 1.2 && < 1.4
                    , test-framework         >= 0.6 && < 1
@@ -146,7 +146,7 @@ test-suite tests
                    , Pos
                    , Prim
                    , Util
-  build-depends:     base                   >= 4.7 && < 5
+  build-depends:     base                   >= 4.6 && < 5
                    , megaparsec             >= 4.0.0
                    , mtl                    == 2.*
                    , transformers           == 0.4.*
@@ -164,7 +164,7 @@ benchmark benchmarks
   hs-source-dirs:    benchmarks
   type:              exitcode-stdio-1.0
   ghc-options:       -O2 -Wall -rtsopts
-  build-depends:     base                   >= 4.7 && < 5
+  build-depends:     base                   >= 4.6 && < 5
                    , megaparsec             >= 4.0.0
                    , criterion              >= 0.6.2.1 && < 1.2
                    , text                   >= 1.2 && < 2

--- a/old-tests/Bugs/Bug39.hs
+++ b/old-tests/Bugs/Bug39.hs
@@ -3,7 +3,9 @@ module Bugs.Bug39 (main) where
 
 import Control.Applicative (empty)
 import Control.Monad (void)
+#if MIN_VERSION_base(4,7,0)
 import Data.Either (isLeft, isRight)
+#endif
 
 import Text.Megaparsec
 import Text.Megaparsec.String
@@ -12,6 +14,14 @@ import qualified Text.Megaparsec.Lexer as L
 import Test.Framework
 import Test.Framework.Providers.HUnit
 import Test.HUnit hiding (Test)
+
+#if !MIN_VERSION_base(4,7,0)
+isRight, isLeft :: Either a b -> Bool
+isRight (Right _) = True
+isRight _         = False
+isLeft  (Left _ ) = True
+isLeft  _         = False
+#endif
 
 shouldFail :: [String]
 shouldFail = [" 1", " +1", " -1"]

--- a/tests/Error.hs
+++ b/tests/Error.hs
@@ -31,7 +31,9 @@
 
 module Error (tests) where
 
+#if MIN_VERSION_base(4,7,0)
 import Data.Bool (bool)
+#endif
 import Data.List (isPrefixOf, isInfixOf)
 
 import Test.Framework
@@ -44,6 +46,11 @@ import Text.Megaparsec.Pos
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>), (<*>))
+#endif
+#if !MIN_VERSION_base(4,7,0)
+bool :: a -> a -> Bool -> a
+bool f _ False = f
+bool _ t True  = t
 #endif
 
 tests :: Test

--- a/tests/Expr.hs
+++ b/tests/Expr.hs
@@ -30,7 +30,9 @@
 module Expr (tests) where
 
 import Control.Applicative (some, (<|>))
+#if MIN_VERSION_base(4,7,0)
 import Data.Bool (bool)
+#endif
 
 import Test.Framework
 import Test.Framework.Providers.QuickCheck2 (testProperty)
@@ -45,6 +47,12 @@ import Util
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>), (<*), (<*>), (*>), pure)
+#endif
+
+#if !MIN_VERSION_base(4,7,0)
+bool :: a -> a -> Bool -> a
+bool f _ False = f
+bool _ t True  = t
 #endif
 
 tests :: Test

--- a/tests/Lexer.hs
+++ b/tests/Lexer.hs
@@ -31,7 +31,9 @@ module Lexer (tests) where
 
 import Control.Applicative (empty)
 import Control.Monad (void)
+#if MIN_VERSION_base(4,7,0)
 import Data.Bool (bool)
+#endif
 import Data.Char
   ( readLitChar
   , showLitChar
@@ -58,6 +60,11 @@ import Util
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>), (<*), (<*>))
+#endif
+#if !MIN_VERSION_base(4,7,0)
+bool :: a -> a -> Bool -> a
+bool f _ False = f
+bool _ t True  = t
 #endif
 
 tests :: Test

--- a/tests/Perm.hs
+++ b/tests/Perm.hs
@@ -30,7 +30,9 @@
 module Perm (tests) where
 
 import Control.Applicative
+#if MIN_VERSION_base(4,7,0)
 import Data.Bool (bool)
+#endif
 import Data.List (nub, elemIndices)
 
 import Test.Framework
@@ -41,6 +43,11 @@ import Text.Megaparsec.Char
 import Text.Megaparsec.Perm
 
 import Util
+#if !MIN_VERSION_base(4,7,0)
+bool :: a -> a -> Bool -> a
+bool f _ False = f
+bool _ t True  = t
+#endif
 
 tests :: Test
 tests = testGroup "Permutation phrases parsers"

--- a/tests/Prim.hs
+++ b/tests/Prim.hs
@@ -32,7 +32,9 @@
 module Prim (tests) where
 
 import Control.Applicative
+#if MIN_VERSION_base(4,7,0)
 import Data.Bool (bool)
+#endif
 import Data.Char (isLetter, toUpper)
 import Data.Foldable (asum)
 import Data.List (isPrefixOf)
@@ -57,6 +59,11 @@ import Text.Megaparsec.String
 
 import Pos ()
 import Util
+#if !MIN_VERSION_base(4,7,0)
+bool :: a -> a -> Bool -> a
+bool f _ False = f
+bool _ t True  = t
+#endif
 
 tests :: Test
 tests = testGroup "Primitive parser combinators"


### PR DESCRIPTION
This version introduces several `#if` for `bool` from `Data.Bool`, and (in one case), for `isLeft` and `isRight`.

Since this approach isn't really clean, I suggest to remove compatibility to base-4.6.0.0 on the second patch release of GHC 8.0, or considering an additional (single) module for those functions (if GHC 7.6 compatibility is a long term concern).

(Sorry, that took a while, I ran into some `sh` trouble due to some incompatibilities between several msys versions and couldn't install `time-*`. That's what I get for running Windows.)

This PR fixes #46.