### PR TITLE
Remove '\' from manyErr

### DIFF
--- a/Text/Megaparsec/Prim.hs
+++ b/Text/Megaparsec/Prim.hs
@@ -289,7 +289,7 @@ manyAcc p = ParsecT $ \s cok cerr eok _ ->
 manyErr :: a
 manyErr = error
   "Text.Megaparsec.Prim.many: combinator 'many' is applied to a parser \
-  \that accepts an empty string."
+   that accepts an empty string."
 
 instance Monad (ParsecT s m) where
   return = pReturn


### PR DESCRIPTION
It gets interpreted as a tab character and this happens:

<img width="815" alt="screen shot 2015-10-30 at 2 28 09 pm" src="https://cloud.githubusercontent.com/assets/853032/10854499/7965a7ec-7f12-11e5-8017-950c819d2f97.png">
