### PR TITLE
Update stack to latest LTS 4.0

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-3.9
+resolver: lts-4.0
 packages:
 - '.'


### PR DESCRIPTION
Any reason not to update to the latest Stack LTS? Seems like [Travis is happy](https://travis-ci.org/stackbuilders/megaparsec/builds/101284089).