### PR TITLE
Define MonadFail & Semigroup instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2],sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3],sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1],sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
 

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -34,13 +34,14 @@ import Control.Exception (Exception)
 import Data.List (intercalate)
 import Data.Maybe (fromMaybe)
 import Data.Typeable (Typeable)
+import Data.Semigroup (Semigroup((<>)))
 
 import Text.Megaparsec.Pos
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>))
 import Data.Foldable (foldMap)
-import Data.Monoid
+import Data.Monoid (Monoid(..))
 #endif
 
 -- | This data type represents parse error messages.
@@ -92,7 +93,10 @@ instance Show ParseError where
 
 instance Monoid ParseError where
   mempty  = newErrorUnknown (initialPos "")
-  mappend = mergeError
+  mappend = (<>)
+
+instance Semigroup ParseError where
+  (<>) = mergeError
 
 instance Exception ParseError
 

--- a/Text/Megaparsec/Lexer.hs
+++ b/Text/Megaparsec/Lexer.hs
@@ -297,7 +297,9 @@ ii = "incorrect indentation"
 
 charLiteral :: MonadParsec s m Char => m Char
 charLiteral = label "literal character" $ do
-  r@(x:_) <- lookAhead $ count' 1 8 C.anyChar
+  -- The @~@ is needed to avoid requiring a MonadFail constraint,
+  -- and we do know that r will be non-empty if count' succeeds.
+  ~r@(x:_) <- lookAhead $ count' 1 8 C.anyChar
   case listToMaybe (readLitChar r) of
     Just (c, r') -> count (length r - length r') C.anyChar >> return c
     Nothing      -> unexpected (showToken x)

--- a/Text/Megaparsec/Prim.hs
+++ b/Text/Megaparsec/Prim.hs
@@ -44,6 +44,7 @@ module Text.Megaparsec.Prim
 where
 
 import Control.Monad
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Cont.Class
 import Control.Monad.Error.Class
 import Control.Monad.Identity
@@ -51,7 +52,7 @@ import Control.Monad.Reader.Class
 import Control.Monad.State.Class hiding (state)
 import Control.Monad.Trans
 import Control.Monad.Trans.Identity
-import Data.Monoid
+import Data.Semigroup
 import qualified Control.Applicative as A
 import qualified Control.Monad.Trans.Reader as L
 import qualified Control.Monad.Trans.State.Lazy as L
@@ -137,7 +138,7 @@ data Result a
 -- unexpected 'a'
 -- expecting 'r' or end of input
 
-newtype Hints = Hints [[String]] deriving Monoid
+newtype Hints = Hints [[String]] deriving (Monoid, Semigroup)
 
 -- | Convert 'ParseError' record into 'Hints'.
 
@@ -315,6 +316,9 @@ manyErr = error $
 instance Monad (ParsecT s m) where
   return = pure
   (>>=)  = pBind
+  fail   = Fail.fail
+
+instance Fail.MonadFail (ParsecT s m) where
   fail   = pFail
 
 pPure :: a -> ParsecT s m a

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -61,6 +61,12 @@ library
                     , mtl          == 2.*
                     , text         >= 0.2
                     , transformers >= 0.4 && < 0.6
+
+  if !impl(ghc >= 8.0)
+    -- packages providing modules that moved into base-4.9.0.0
+    build-depends:    fail         == 4.9.*
+                    , semigroups   == 0.18.*
+
   default-extensions: CPP
                     , DeriveDataTypeable
                     , FlexibleContexts
@@ -88,6 +94,10 @@ library
                     , Text.Megaparsec.Text.Lazy
   if flag(dev)
     ghc-options:      -Wall -Werror
+    if impl(ghc >= 8.0)
+      ghc-options:    -Wcompat
+      ghc-options:    -Wnoncanonical-monadfail-instances
+      ghc-options:    -Wnoncanonical-monoid-instances
   else
     ghc-options:      -O2 -Wall
   default-language:   Haskell2010


### PR DESCRIPTION
This also enables the respective warnings flags in dev mode
to help megaparsec forward compatible.

The dependencies on `semigroup` and `fail` are conditional on
`impl(ghc >= 8)` and avoid CPP and conditionally defined instances
(which would result in an conditional API).