### PR TITLE
Replace `String` with `Foldable f => f Char` for some combinators

### DIFF
--- a/Text/Megaparsec/Expr.hs
+++ b/Text/Megaparsec/Expr.hs
@@ -144,7 +144,11 @@ type Batch m a =
 -- | A helper to separate various operators (binary, unary, and according to
 -- associativity) and return them in a tuple.
 
-splitOp :: MonadParsec s m t => Operator m a -> Batch m a -> Batch m a
+splitOp ::
+#if !MIN_VERSION_base(4,9,0)
+  MonadParsec s m t =>
+#endif
+  Operator m a -> Batch m a -> Batch m a
 splitOp (InfixR  op) (r, l, n, pre, post) = (op:r, l, n, pre, post)
 splitOp (InfixL  op) (r, l, n, pre, post) = (r, op:l, n, pre, post)
 splitOp (InfixN  op) (r, l, n, pre, post) = (r, l, op:n, pre, post)

--- a/Text/Megaparsec/Perm.hs
+++ b/Text/Megaparsec/Perm.hs
@@ -108,11 +108,15 @@ f <$?> xp = newperm f <|?> xp
        => PermParser s m (a -> b) -> (a, m a) -> PermParser s m b
 perm <|?> (x, p) = addopt perm x p
 
-newperm :: MonadParsec s m t
-        => (a -> b) -> PermParser s m (a -> b)
+newperm ::
+#if !MIN_VERSION_base(4,9,0)
+  MonadParsec s m t =>
+#endif
+  (a -> b) -> PermParser s m (a -> b)
 newperm f = Perm (Just f) []
 
-add :: MonadParsec s m t => PermParser s m (a -> b) -> m a -> PermParser s m b
+add :: MonadParsec s m t
+    => PermParser s m (a -> b) -> m a -> PermParser s m b
 add perm@(Perm _mf fs) p = Perm Nothing (first : fmap insert fs)
   where first = Branch perm p
         insert (Branch perm' p') = Branch (add (mapPerms flip perm') p) p'

--- a/Text/Megaparsec/Prim.hs
+++ b/Text/Megaparsec/Prim.hs
@@ -592,8 +592,11 @@ pNotFollowedBy p = ParsecT $ \s@(State input pos _) _ _ eok eerr ->
       eerr'  _ _ = eok () s mempty
   in unParser p s cok' cerr' eok' eerr'
 
-pWithRecovery :: Stream s t
-  => (ParseError -> ParsecT s m a)
+pWithRecovery ::
+#if !MIN_VERSION_base(4,9,0)
+  Stream s t =>
+#endif
+  (ParseError -> ParsecT s m a)
   -> ParsecT s m a
   -> ParsecT s m a
 pWithRecovery r p = ParsecT $ \s cok cerr eok eerr ->
@@ -747,8 +750,11 @@ setParserState st = updateParserState (const st)
 -- >
 -- > numbers = commaSep integer
 
-parse :: Stream s t
-  => Parsec s a -- ^ Parser to run
+parse ::
+#if !MIN_VERSION_base(4,9,0)
+  Stream s t =>
+#endif
+     Parsec s a -- ^ Parser to run
   -> String     -- ^ Name of source file
   -> s          -- ^ Input for parser
   -> Either ParseError a
@@ -773,7 +779,12 @@ parseMaybe p s =
 -- | The expression @parseTest p input@ applies a parser @p@ against
 -- input @input@ and prints the result to stdout. Used for testing.
 
-parseTest :: (Stream s t, Show a) => Parsec s a -> s -> IO ()
+parseTest :: (
+#if !MIN_VERSION_base(4,9,0)
+    Stream s t, 
+#endif
+    Show a
+  ) => Parsec s a -> s -> IO ()
 parseTest p input =
   case parse p "" input of
     Left  e -> print e
@@ -786,8 +797,11 @@ parseTest p input =
 --
 -- > parseFromFile p file = runParser p file <$> readFile file
 
-runParser :: Stream s t
-  => Parsec s a -- ^ Parser to run
+runParser ::
+#if !MIN_VERSION_base(4,9,0)
+  Stream s t =>
+#endif
+     Parsec s a -- ^ Parser to run
   -> String     -- ^ Name of source file
   -> s          -- ^ Input for parser
   -> Either ParseError a
@@ -800,8 +814,11 @@ runParser p name s = snd $ runParser' p (initialState name s)
 --
 -- @since 4.2.0
 
-runParser' :: Stream s t
-  => Parsec s a -- ^ Parser to run
+runParser' ::
+#if !MIN_VERSION_base(4,9,0)
+  Stream s t =>
+#endif
+     Parsec s a -- ^ Parser to run
   -> State s    -- ^ Initial state
   -> (State s, Either ParseError a)
 runParser' p = runIdentity . runParserT' p
@@ -812,10 +829,13 @@ runParser' p = runIdentity . runParserT' p
 -- underlying monad @m@ that returns either a 'ParseError' ('Left') or a
 -- value of type @a@ ('Right').
 
-runParserT :: (Monad m, Stream s t)
-  => ParsecT s m a -- ^ Parser to run
-  -> String        -- ^ Name of source file
-  -> s             -- ^ Input for parser
+runParserT :: (Monad m
+#if !MIN_VERSION_base(4,9,0)
+              , Stream s t
+#endif
+  ) => ParsecT s m a -- ^ Parser to run
+  -> String          -- ^ Name of source file
+  -> s               -- ^ Input for parser
   -> m (Either ParseError a)
 runParserT p name s = snd `liftM` runParserT' p (initialState name s)
 
@@ -825,9 +845,12 @@ runParserT p name s = snd `liftM` runParserT' p (initialState name s)
 --
 -- @since 4.2.0
 
-runParserT' :: (Monad m, Stream s t)
-  => ParsecT s m a -- ^ Parser to run
-  -> State s       -- ^ Initial state
+runParserT' :: (Monad m
+#if !MIN_VERSION_base(4,9,0)
+               , Stream s t
+#endif
+  ) => ParsecT s m a -- ^ Parser to run
+  -> State s         -- ^ Initial state
   -> m (State s, Either ParseError a)
 runParserT' p s = do
   (Reply s' _ result) <- runParsecT p s
@@ -837,7 +860,11 @@ runParserT' p s = do
 
 -- | Given name of source file and input construct initial state for parser.
 
-initialState :: Stream s t => String -> s -> State s
+initialState ::
+#if !MIN_VERSION_base(4,9,0)
+  Stream s t =>
+#endif
+  String -> s -> State s
 initialState name s = State s (initialPos name) defaultTabWidth
 
 -- | Low-level unpacking of the 'ParsecT' type. 'runParserT' and 'runParser'

--- a/tests/Prim.hs
+++ b/tests/Prim.hs
@@ -671,7 +671,11 @@ prop_stOnFail_3 s = runParser' p (stateFromInput s) === (i, r)
         r = posErr 0 s [if null s then uneEof else uneCh (head s)]
         p = notFollowedBy (string s)
 
-stateFromInput :: Stream s t => s -> State s
+stateFromInput ::
+#if !MIN_VERSION_base(4,9,0)
+  Stream s t =>
+#endif
+  s -> State s
 stateFromInput s = State s (initialPos "") defaultTabWidth
 
 -- ReaderT instance of MonadParsec


### PR DESCRIPTION
This allows for more flexible input of any "container" holding characters rather then the specific representation of `String`. I personally use `Vector Char` often and would like to pass the vector in rather than call `toList` on the container.

Since the changed methods rely on `elem` which is an instance function of `Foldable`, it make sense to use the more general instance, just like `choice` does.

(First pull request, hope I did this right)
(Hopefully this one passes the Travis CI)
