### PR TITLE
More flexible position-advancing function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 * Combinators `oneOf`, `oneOf'`, `noneOf`, and `noneOf'` now accept any
   instance of `Foldable`, not only `String`.
 
+* Moved position-advancing function from arguments of `token` and `tokens`
+  functions to `Stream` type class (named `updatePos`). The new function
+  allows to handle custom streams of tokens where every token contains
+  information about its position in stream better (for example when stream
+  of tokens is produced with happy/alex).
+
+* Changed order of arguments for a number of functions in
+  `Text.Megaparsec.Pos`, allowing for easier point-free composition.
+
 ## Megaparsec 4.4.0
 
 * Now state returned on failure is the exact state of parser at the moment

--- a/Text/Megaparsec/Char.hs
+++ b/Text/Megaparsec/Char.hs
@@ -58,7 +58,6 @@ import Data.Maybe (fromJust)
 
 import Text.Megaparsec.Combinator
 import Text.Megaparsec.Error (Message (..))
-import Text.Megaparsec.Pos
 import Text.Megaparsec.Prim
 import Text.Megaparsec.ShowToken
 
@@ -326,10 +325,11 @@ noneOf' cs = satisfy (`notElemi` cs)
 -- > oneOf cs  = satisfy (`elem` cs)
 
 satisfy :: MonadParsec s m Char => (Char -> Bool) -> m Char
-satisfy f = token updatePosChar testChar
-  where testChar x = if f x
-                     then Right x
-                     else Left . pure . Unexpected . showToken $ x
+satisfy f = token testChar
+  where testChar x =
+          if f x
+            then Right x
+            else Left . pure . Unexpected . showToken $ x
 
 ----------------------------------------------------------------------------
 -- Sequence of characters
@@ -340,7 +340,7 @@ satisfy f = token updatePosChar testChar
 -- > divOrMod = string "div" <|> string "mod"
 
 string :: MonadParsec s m Char => String -> m String
-string = tokens updatePosString (==)
+string = tokens (==)
 
 -- | The same as 'string', but case-insensitive. On success returns string
 -- cased as actually parsed input.
@@ -349,7 +349,7 @@ string = tokens updatePosString (==)
 -- "foObAr"
 
 string' :: MonadParsec s m Char => String -> m String
-string' = tokens updatePosString casei
+string' = tokens casei
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/Text/Megaparsec/Combinator.hs
+++ b/Text/Megaparsec/Combinator.hs
@@ -112,13 +112,15 @@ endBy1 p sep = some (p <* sep)
 -- > simpleComment = string "<!--" >> manyTill anyChar (string "-->")
 
 manyTill :: Alternative m => m a -> m end -> m [a]
-manyTill p end = ([] <$ end) <|> someTill p end
+manyTill p end = go where go = ([] <$ end) <|> ((:) <$> p <*> go)
+{-# INLINE manyTill #-}
 
 -- | @someTill p end@ works similarly to @manyTill p end@, but @p@ should
 -- succeed at least once.
 
 someTill :: Alternative m => m a -> m end -> m [a]
 someTill p end = (:) <$> p <*> manyTill p end
+{-# INLINE someTill #-}
 
 -- | @option x p@ tries to apply parser @p@. If @p@ fails without
 -- consuming input, it returns the value @x@, otherwise the value returned
@@ -152,6 +154,7 @@ sepBy1 p sep = (:) <$> p <*> many (sep *> p)
 
 sepEndBy :: Alternative m => m a -> m sep -> m [a]
 sepEndBy p sep = sepEndBy1 p sep <|> pure []
+{-# INLINE sepEndBy #-}
 
 -- | @sepEndBy1 p sep@ parses /one/ or more occurrences of @p@,
 -- separated and optionally ended by @sep@. Returns a list of values

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -66,6 +66,7 @@ data Message
 isUnexpected :: Message -> Bool
 isUnexpected (Unexpected _) = True
 isUnexpected _              = False
+{-# INLINE isUnexpected #-}
 
 -- | Check if given 'Message' is created with 'Expected' constructor.
 --
@@ -74,6 +75,7 @@ isUnexpected _              = False
 isExpected :: Message -> Bool
 isExpected (Expected _) = True
 isExpected _            = False
+{-# INLINE isExpected #-}
 
 -- | Check if given 'Message' is created with 'Message' constructor.
 --
@@ -82,6 +84,7 @@ isExpected _            = False
 isMessage :: Message -> Bool
 isMessage (Message _) = True
 isMessage _           = False
+{-# INLINE isMessage #-}
 
 -- | Extract the message string from an error message.
 
@@ -89,11 +92,13 @@ messageString :: Message -> String
 messageString (Unexpected s) = s
 messageString (Expected   s) = s
 messageString (Message    s) = s
+{-# INLINE messageString #-}
 
 -- | Test if message string is empty.
 
 badMessage :: Message -> Bool
 badMessage = null . messageString
+{-# INLINE badMessage #-}
 
 -- | The data type @ParseError@ represents parse errors. It provides the
 -- source position ('SourcePos') of the error and a list of error messages
@@ -137,7 +142,7 @@ newErrorMessage m = newErrorMessages [m]
 -- @since 4.2.0
 
 newErrorMessages :: [Message] -> SourcePos -> ParseError
-newErrorMessages ms pos = addErrorMessages ms $ newErrorUnknown pos
+newErrorMessages ms pos = addErrorMessages ms (newErrorUnknown pos)
 
 -- | @newErrorUnknown pos@ creates 'ParseError' without any associated
 -- message but with specified position @pos@.
@@ -154,6 +159,7 @@ addErrorMessage m (ParseError pos ms) =
   ParseError pos $ if badMessage m then ms else pre ++ [m] ++ post
   where pre  = filter (< m) ms
         post = filter (> m) ms
+{-# INLINE addErrorMessage #-}
 
 -- | @addErrorMessages ms err@ returns @err@ with messages @ms@ added. The
 -- function is defined in terms of 'addErrorMessage'.
@@ -162,6 +168,7 @@ addErrorMessage m (ParseError pos ms) =
 
 addErrorMessages :: [Message] -> ParseError -> ParseError
 addErrorMessages ms err = foldr addErrorMessage err ms
+{-# INLINE addErrorMessages #-}
 
 -- | @setErrorMessage m err@ returns @err@ with message @m@ added. This
 -- function also deletes all existing error messages that were created with

--- a/Text/Megaparsec/Pos.hs
+++ b/Text/Megaparsec/Pos.hs
@@ -132,6 +132,8 @@ setSourceColumn c (SourcePos n l _) = newPos n l c
 -- incremented by 1.
 --
 -- If given tab width is not positive, 'defaultTabWidth' will be used.
+--
+-- @since 5.0.0
 
 defaultUpdatePos
   :: Int               -- ^ Tab width

--- a/Text/Megaparsec/Prim.hs
+++ b/Text/Megaparsec/Prim.hs
@@ -217,6 +217,8 @@ class (ShowToken t, ShowToken [t]) => Stream s t | s -> t where
   -- stream with happy\/alex), then the best strategy is to use the start
   -- position as actual element position and provide the end position of the
   -- token as incremented one.
+  --
+  -- @since 5.0.0
 
   updatePos
     :: Proxy s         -- ^ Proxy clarifying stream type

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -149,11 +149,13 @@ test-suite tests
   build-depends:      base           >= 4.6 && < 5
                     , HUnit          >= 1.2 && < 1.4
                     , QuickCheck     >= 2.4 && < 3
+                    , bytestring
                     , megaparsec     >= 4.4.0
                     , mtl            == 2.*
                     , test-framework >= 0.6 && < 1
                     , test-framework-hunit       >= 0.3 && < 0.4
                     , test-framework-quickcheck2 >= 0.3 && < 0.4
+                    , text           >= 0.2
                     , transformers   >= 0.4 && < 0.6
   default-extensions: CPP
                     , FlexibleContexts

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -67,6 +67,9 @@ library
     build-depends:    fail         == 4.9.*
                     , semigroups   == 0.18.*
 
+  if !impl(ghc >= 7.8)
+    build-depends:    tagged       == 0.8.*
+
   default-extensions: CPP
                     , DeriveDataTypeable
                     , FlexibleContexts

--- a/tests/Pos.hs
+++ b/tests/Pos.hs
@@ -39,6 +39,7 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.QuickCheck
 
 import Text.Megaparsec.Pos
+import Util (updatePosString)
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative ((<$>), (<*>), pure)
@@ -104,7 +105,7 @@ prop_incSourceLine pos l' =
   d sourceLine   (+ l) pos incp &&
   d sourceColumn id    pos incp
   where l    = getNonNegative l'
-        incp = incSourceLine pos l
+        incp = incSourceLine l pos
 
 prop_incSourceColumn :: SourcePos -> NonNegative Int -> Bool
 prop_incSourceColumn pos c' =
@@ -112,14 +113,14 @@ prop_incSourceColumn pos c' =
   d sourceLine   id    pos incp &&
   d sourceColumn (+ c) pos incp
   where c    = getNonNegative c'
-        incp = incSourceColumn pos c
+        incp = incSourceColumn c pos
 
 prop_setSourceName :: SourcePos -> String -> Bool
 prop_setSourceName pos n =
   d sourceName   (const n) pos setp &&
   d sourceLine   id        pos setp &&
   d sourceColumn id        pos setp
-  where setp = setSourceName pos n
+  where setp = setSourceName n pos
 
 prop_setSourceLine :: SourcePos -> Positive Int -> Bool
 prop_setSourceLine pos l' =
@@ -127,7 +128,7 @@ prop_setSourceLine pos l' =
   d sourceLine   (const l) pos setp &&
   d sourceColumn id        pos setp
   where l    = getPositive l'
-        setp = setSourceLine pos l
+        setp = setSourceLine l pos
 
 prop_setSourceColumn :: SourcePos -> Positive Int -> Bool
 prop_setSourceColumn pos c' =
@@ -135,7 +136,7 @@ prop_setSourceColumn pos c' =
   d sourceLine   id        pos setp &&
   d sourceColumn (const c) pos setp
   where c    = getPositive c'
-        setp = setSourceColumn pos c
+        setp = setSourceColumn c pos
 
 prop_updating :: Int -> SourcePos -> String -> Bool
 prop_updating w pos "" = updatePosString w pos "" == pos

--- a/tests/Prim.hs
+++ b/tests/Prim.hs
@@ -120,7 +120,8 @@ tests = testGroup "Primitive parser combinators"
   , testCase     "combinator withRecovery mcerr-reerr" case_withRecovery_7
   , testCase     "combinator eof return value"    case_eof
   , testProperty "combinator token"                    prop_token
-  , testProperty "combinator tokens"                   prop_tokens
+  , testProperty "combinator tokens"                   prop_tokens_0
+  , testProperty "combinator tokens (consumption)"     prop_tokens_1
   , testProperty "parser state position"               prop_state_pos
   , testProperty "parser state input"                  prop_state_input
   , testProperty "parser state tab width"              prop_state_tab
@@ -576,9 +577,18 @@ prop_token s = checkParser' p r s
           | isLetter h && length s > 1 = posErr 1 s [uneCh (s !! 1), exEof]
           | otherwise = posErr 0 s [uneCh h]
 
-prop_tokens :: String -> String -> Property
-prop_tokens a = checkString p a (==) (showToken a)
+prop_tokens_0 :: String -> String -> Property
+prop_tokens_0 a = checkString p a (==) (showToken a)
   where p = tokens (==) a
+
+prop_tokens_1 :: String -> String -> String -> Property
+prop_tokens_1 pre post post' =
+  not (post `isPrefixOf` post') ==>
+  (leftover === "" .||. leftover === s)
+  where p = tokens (==) (pre ++ post)
+        s = pre ++ post'
+        st = stateFromInput s
+        leftover = stateInput . fst $ runParser' p st
 
 -- Parser state combinators
 

--- a/tests/Prim.hs
+++ b/tests/Prim.hs
@@ -566,7 +566,7 @@ case_eof = checkCase eof (Right ()) ""
 prop_token :: String -> Property
 prop_token s = checkParser' p r s
   where p :: MonadParsec s m Char => m Char
-        p = token updatePosChar testChar
+        p = token testChar
         testChar x = if isLetter x
           then Right x
           else Left . pure . Unexpected . showToken $ x
@@ -578,7 +578,7 @@ prop_token s = checkParser' p r s
 
 prop_tokens :: String -> String -> Property
 prop_tokens a = checkString p a (==) (showToken a)
-  where p = tokens updatePosString (==) a
+  where p = tokens (==) a
 
 -- Parser state combinators
 

--- a/tests/Util.hs
+++ b/tests/Util.hs
@@ -35,6 +35,7 @@ module Util
   , simpleParse
   , checkChar
   , checkString
+  , updatePosString
   , (/=\)
   , (!=!)
   , abcRow
@@ -53,6 +54,7 @@ where
 
 import Control.Monad.Reader
 import Control.Monad.Trans.Identity
+import Data.Foldable (foldl')
 import Data.Maybe (maybeToList)
 import qualified Control.Monad.State.Lazy    as L
 import qualified Control.Monad.State.Strict  as S
@@ -161,6 +163,16 @@ checkString p a' test l s' = checkParser p (w a' 0 s') s'
           | test a s  = w as i' ss
           | otherwise = posErr 0 s' [uneStr (take i' s'), exSpec l]
             where i'  = succ i
+
+-- | A helper function that is used to advance 'SourcePos' given a 'String'.
+
+updatePosString
+  :: Int               -- ^ Tab width
+  -> SourcePos         -- ^ Initial position
+  -> String            -- ^ 'String' — collection of tokens to process
+  -> SourcePos         -- ^ Final position
+updatePosString w = foldl' f
+  where f p t = snd (defaultUpdatePos w p t)
 
 infix 4 /=\   -- preserve whitespace on automatic trim
 


### PR DESCRIPTION
This PR aims to improve experience of users who work with custom input streams. In particular with such streams where tokens have start/end positions attached (for example when input stream is generated by alex/happy).

TODO list:

- [x] Check how this affects performance
- [x] Update `CHANGELOG.md`
- [x] Don't forget to add `@since` to new functions
- [x] Write test that checks that `string` never consumes input when it fails
- [x] Write tests for the new feature and also test non-`String` streams (`Text`, `ByteString`)
