### PR TITLE
Labelling expected items

### DIFF
--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -27,7 +27,7 @@
 -- POSSIBILITY OF SUCH DAMAGE.
 
 name:                 megaparsec
-version:              5.0.0
+version:              5.1.0
 cabal-version:        >= 1.10
 license:              BSD2
 license-file:         LICENSE.md


### PR DESCRIPTION
Resolves #111. The constructor I add actually supports annotating any `ErrorItem` but I'm not sure whether this is the "best" way to go about it.