### PR TITLE
Make indentBlock/IndentNone work with many like IndentMany/Some does

### DIFF
--- a/Text/Megaparsec/Lexer.hs
+++ b/Text/Megaparsec/Lexer.hs
@@ -289,7 +289,7 @@ indentBlock sc r = do
   ref <- indentLevel
   a   <- r
   case a of
-    IndentNone x -> return x
+    IndentNone x -> sc *> return x
     IndentMany indent f p -> do
       mlvl <- optional . try $ C.eol *> indentGuard sc GT ref
       case mlvl of


### PR DESCRIPTION
Even though the haddock for `Text.Megaparsec.Lexer.space` says that

    Parsing of white space is an important part of any parser. We
    propose a convention where every lexeme parser assumes no spaces
    before the lexeme and consumes all spaces after the lexeme;

all the indentation-sensitive parsing combinators assume/consume
whitespace _before_ the thing to be parsed. This would normally mean
they can't be used with combinators like `many` and `some` without using
`try` (and sacrificing performance). Fortunately `indentBlock` also
consumes whitespace _after_, but unfortunately it didn't do that in the
`IndentNone` case. Now it does and it works with many and some without
try!  \o/