### PR TITLE
Drop support for GHC 7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ sudo: false
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.6.3
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3],sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.8.4
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.10.3],sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
@@ -28,28 +26,20 @@ install:
  - cabal install --only-dependencies --enable-tests
 
 script:
- - case "$CABALVER" in
-    "1.16") cabal configure --enable-tests -v2 -f dev ;;
-    "1.18") cabal configure --enable-tests --enable-library-coverage -v2 -f dev ;;
-    *)      cabal configure --enable-tests --enable-coverage -v2 -f dev ;;
-   esac
+ - cabal configure --enable-tests --enable-coverage -v2 -f dev
  - travis_wait 60 cabal build
- - case "$GHCVER" in
-    "7.6.3") true ;;
-    *)       cabal test --show-details=always --test-option=--qc-max-success=1000 ;;
-   esac
+ - cabal test --show-details=always --test-option=--qc-max-success=1000
  - cabal sdist
- - if [ "$CABALVER" != "1.16" ]; then
-    cabal haddock | grep "100%" | wc -l | grep "14";
-   fi
+ - cabal haddock | grep "100%" | wc -l | grep "14"
 
 after_script:
  - cabal install hpc-coveralls
  - export PATH=~/.cabal/bin:$PATH
- - case "$GHCVER" in
-    "7.6.3") true ;;
-    *) hpc-coveralls --coverage-mode=StrictlyFullLines --exclude-dir=bench-speed --exclude-dir=bench-memory --exclude-dir=tests tests ;;
-   esac
+ - hpc-coveralls --coverage-mode=StrictlyFullLines
+                 --exclude-dir=bench-memory
+                 --exclude-dir=bench-speed
+                 --exclude-dir=tests
+                 tests
 
 notifications:
   email: false

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -61,7 +61,7 @@ flag dev
 
 library
   build-depends:      QuickCheck   >= 2.7   && < 3.0
-                    , base         >= 4.6   && < 5.0
+                    , base         >= 4.7   && < 5.0
                     , bytestring   >= 0.2   && < 0.11
                     , containers   >= 0.5   && < 0.6
                     , deepseq      >= 1.3   && < 1.5
@@ -122,7 +122,7 @@ test-suite tests
                     , Text.Megaparsec.PosSpec
                     , Text.Megaparsec.PrimSpec
   build-depends:      QuickCheck   >= 2.7   && < 3.0
-                    , base         >= 4.6   && < 5.0
+                    , base         >= 4.7   && < 5.0
                     , bytestring   >= 0.2   && < 0.11
                     , containers   >= 0.5   && < 0.6
                     , exceptions   >= 0.6   && < 0.9
@@ -147,7 +147,7 @@ benchmark bench-speed
   main-is:            Main.hs
   hs-source-dirs:     bench-speed
   type:               exitcode-stdio-1.0
-  build-depends:      base         >= 4.6  && < 5.0
+  build-depends:      base         >= 4.7  && < 5.0
                     , criterion    >= 0.6.2.1 && < 1.2
                     , deepseq      >= 1.3  && < 1.5
                     , megaparsec   >= 5.1.2
@@ -161,7 +161,7 @@ benchmark bench-memory
   main-is:            Main.hs
   hs-source-dirs:     bench-memory
   type:               exitcode-stdio-1.0
-  build-depends:      base         >= 4.6  && < 5.0
+  build-depends:      base         >= 4.7  && < 5.0
                     , deepseq      >= 1.3  && < 1.5
                     , megaparsec   >= 5.1.2
                     , weigh        >= 0.0.3

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,11 +1,1 @@
-{-# LANGUAGE CPP #-}
-
-#if __GLASGOW_HASKELL__ >= 708
 {-# OPTIONS_GHC -F -pgmF hspec-discover #-}
-#else
-
-module Spec (main) where
-
-main :: IO ()
-main = return ()
-#endif


### PR DESCRIPTION
This is a PR that instroduces the change, but we don't want to merge it yet. Support for GHC 7.6 will be dropped at some point though, probably after release of version 5.2. Related: #165.