### PR TITLE
Count processed tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@
   implementation), `count'` (considerable improvement), and `many`
   (marginal improvement, simpler implementation).
 
+* Added `stateTokensProcessed` field to parser state and helper functions
+  `getTokensProcessed` and `setTokensProcessed`. The field contains number
+  of processed tokens so far. This allows, for example, create wrappers that
+  return just parsed fragment of input stream alongside with result of
+  parsing. (It was possible before, but very inefficient because it required
+  traversing entire input stream twice.)
+
 ## Megaparsec 5.1.2
 
 * Stopped using property tests with `dbg` helper to avoid flood of debugging

--- a/Text/Megaparsec.hs
+++ b/Text/Megaparsec.hs
@@ -53,13 +53,13 @@ module Text.Megaparsec
   ( -- * Running parser
     Parsec
   , ParsecT
+  , parse
+  , parseMaybe
+  , parseTest
   , runParser
   , runParser'
   , runParserT
   , runParserT'
-  , parse
-  , parseMaybe
-  , parseTest
     -- * Combinators
   , (A.<|>)
   -- $assocbo
@@ -160,6 +160,8 @@ module Text.Megaparsec
   , setPosition
   , pushPosition
   , popPosition
+  , getTokensProcessed
+  , setTokensProcessed
   , getTabWidth
   , setTabWidth
   , getParserState

--- a/tests/Test/Hspec/Megaparsec.hs
+++ b/tests/Test/Hspec/Megaparsec.hs
@@ -320,7 +320,11 @@ succeedsLeaving :: ( ShowToken (Token s)
 -- column).
 
 initialState :: s -> State s
-initialState s = State s (initialPos "" :| []) defaultTabWidth
+initialState s = State
+  { stateInput           = s
+  , statePos             = initialPos "" :| []
+  , stateTokensProcessed = 0
+  , stateTabWidth        = defaultTabWidth }
 
 ----------------------------------------------------------------------------
 -- Helpers


### PR DESCRIPTION
Close #170.

OK, there is actually a lot of work to be done, off the top of my head:

- [x] Properly implement the counter in `tokens`.
- [x] Investigate the test failure.
- [x] Use the new counter to make `dbg` more efficient.
- [x] Ensure that it does not make things slower.
- [x] Add tests to check that `token` and `tokens` increment `stateTokensProcessed` correctly.
- [x] Add helpers to set and get number of processed toknes so far, similarily to what we have for all others components of parser state.
- [x] Test the helpers (should be trivial).
- [x] Update the `CHANGELOG.md` file.
