### PR TITLE
Make () an error component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Dropped support for GHC 7.6.
 
+* Added an `ErrorComponent` instance for `()`.
+
 ## Megaparsec 5.2.0
 
 * Added `MonadParsec` instance for `RWST`.

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -100,6 +100,10 @@ class Ord e => ErrorComponent e where
     -> Pos             -- ^ Actual indentation level
     -> e
 
+instance ErrorComponent () where
+  representFail _ = ()
+  representIndentation _ _ _ = ()
+
 -- | “Default error component”. This in our instance of 'ErrorComponent'
 -- provided out-of-box.
 --


### PR DESCRIPTION
This can be used to discard unnecessary error information in simplistic parsers.