### PR TITLE
Define ‘Semigroup’ and ‘Monoid’ for ‘ParsecT’

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Added the `getNextTokenPosition`, which returns position where the next
   token in the stream begins.
 
+* Defined `Semigroup` and `Monoid` instances of `ParsecT`.
+
 * Dropped support for GHC 7.6.
 
 * Added an `ErrorComponent` instance for `()`.

--- a/Text/Megaparsec/Prim.hs
+++ b/Text/Megaparsec/Prim.hs
@@ -365,6 +365,18 @@ newtype ParsecT e s m a = ParsecT
       -> (ParseError (Token s) e -> State s -> m b) -- empty-error
       -> m b }
 
+instance (ErrorComponent e, Stream s, Semigroup a)
+    => Semigroup (ParsecT e s m a) where
+  (<>) = A.liftA2 (<>)
+  {-# INLINE (<>) #-}
+
+instance (ErrorComponent e, Stream s, Monoid a)
+    => Monoid (ParsecT e s m a) where
+  mempty = pure mempty
+  {-# INLINE mempty #-}
+  mappend = A.liftA2 mappend
+  {-# INLINE mappend #-}
+
 instance Functor (ParsecT e s m) where
   fmap = pMap
 

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -96,10 +96,6 @@ library
                     , Text.Megaparsec.Text.Lazy
   if flag(dev)
     ghc-options:      -Wall -Werror
-    if impl(ghc >= 8.0)
-      ghc-options:    -Wcompat
-      ghc-options:    -Wnoncanonical-monadfail-instances
-      ghc-options:    -Wnoncanonical-monoid-instances
   else
     ghc-options:      -O2 -Wall
   default-language:   Haskell2010

--- a/tests/Text/Megaparsec/PrimSpec.hs
+++ b/tests/Text/Megaparsec/PrimSpec.hs
@@ -216,6 +216,21 @@ spec = do
                  st = st' { stateInput = h : stateInput st' }
              runParser' p st `shouldBe` (st, (Right . Just . spanStart) h)
 
+  describe "ParsecT Semigroup instance" $
+    it "the associative operation works" $
+      property $ \a b -> do
+        let p = pure [a] G.<> pure [b]
+        prs p "" `shouldParse` ([a,b] :: [Int])
+
+  describe "ParsecT Monoid instance" $ do
+    it "mempty works" $ do
+      let p = mempty
+      prs p "" `shouldParse` ([] :: [Int])
+    it "mappend works" $
+      property $ \a b -> do
+        let p = pure [a] `mappend` pure [b]
+        prs p "" `shouldParse` ([a,b] :: [Int])
+
   describe "ParsecT Functor instance" $ do
     it "obeys identity law" $
       property $ \n ->


### PR DESCRIPTION
Close #200.