### PR TITLE
Move QuickCheck dep out of library

### DIFF
--- a/Text/Megaparsec/Pos.hs
+++ b/Text/Megaparsec/Pos.hs
@@ -39,7 +39,6 @@ import Data.Data (Data)
 import Data.Semigroup
 import Data.Typeable (Typeable)
 import GHC.Generics
-import Test.QuickCheck
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
@@ -57,9 +56,6 @@ import Data.Word (Word)
 
 newtype Pos = Pos Word
   deriving (Show, Eq, Ord, Data, Typeable, NFData)
-
-instance Arbitrary Pos where
-  arbitrary = unsafePos <$> (getSmall <$> arbitrary `suchThat` (> 0))
 
 -- | Construction of 'Pos' from an instance of 'Integral'. The function
 -- throws 'InvalidPosException' when given non-positive argument. Note that
@@ -105,14 +101,6 @@ instance Read Pos where
       ("Pos", r2) <- lex r1
       (x,     r3) <- readsPrec 11 r2
       (,r3) <$> mkPos (x :: Integer)
-
-instance Arbitrary SourcePos where
-  arbitrary = SourcePos
-    <$> sized (\n -> do
-          k <- choose (0, n `div` 2)
-          vectorOf k arbitrary)
-    <*> (unsafePos <$> choose (1, 1000))
-    <*> (unsafePos <$> choose (1,  100))
 
 -- | The exception is thrown by 'mkPos' when its argument is not a positive
 -- number.

--- a/Text/Megaparsec/Prim.hs
+++ b/Text/Megaparsec/Prim.hs
@@ -86,7 +86,6 @@ import Data.Typeable (Typeable)
 import Debug.Trace
 import GHC.Generics
 import Prelude hiding (all)
-import Test.QuickCheck hiding (Result (..), label)
 import qualified Control.Applicative               as A
 import qualified Control.Monad.Fail                as Fail
 import qualified Control.Monad.RWS.Lazy            as L
@@ -130,18 +129,6 @@ data State s = State
   } deriving (Show, Eq, Data, Typeable, Generic)
 
 instance NFData s => NFData (State s)
-
-instance Arbitrary a => Arbitrary (State a) where
-  arbitrary = State
-    <$> arbitrary
-    <*>
-#if !MIN_VERSION_QuickCheck(2,9,0)
-      (NE.fromList . getNonEmpty <$> arbitrary)
-#else
-      arbitrary
-#endif
-    <*> choose (1, 10000)
-    <*> (unsafePos <$> choose (1, 20))
 
 -- | All information available after parsing. This includes consumption of
 -- input, success (with returned value) or failure (with parse error), and

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -33,8 +33,7 @@ flag dev
   default:            False
 
 library
-  build-depends:      QuickCheck   >= 2.7   && < 3.0
-                    , base         >= 4.7   && < 5.0
+  build-depends:      base         >= 4.7   && < 5.0
                     , bytestring   >= 0.2   && < 0.11
                     , containers   >= 0.5   && < 0.6
                     , deepseq      >= 1.3   && < 1.5
@@ -85,6 +84,7 @@ test-suite tests
                     , Text.Megaparsec.PermSpec
                     , Text.Megaparsec.PosSpec
                     , Text.Megaparsec.PrimSpec
+                    , Text.Megaparsec.Types
   build-depends:      QuickCheck   >= 2.7   && < 3.0
                     , base         >= 4.7   && < 5.0
                     , bytestring   >= 0.2   && < 0.11

--- a/tests/Text/Megaparsec/ErrorSpec.hs
+++ b/tests/Text/Megaparsec/ErrorSpec.hs
@@ -13,6 +13,7 @@ import Test.Hspec
 import Test.QuickCheck
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos
+import Text.Megaparsec.Types()
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Semigroup     as S
 import qualified Data.Set           as E

--- a/tests/Text/Megaparsec/LexerSpec.hs
+++ b/tests/Text/Megaparsec/LexerSpec.hs
@@ -22,6 +22,7 @@ import Text.Megaparsec.Error
 import Text.Megaparsec.Lexer
 import Text.Megaparsec.Pos
 import Text.Megaparsec.Prim
+import Text.Megaparsec.Types()
 import qualified Text.Megaparsec.Char as C
 
 spec :: Spec

--- a/tests/Text/Megaparsec/PosSpec.hs
+++ b/tests/Text/Megaparsec/PosSpec.hs
@@ -10,6 +10,7 @@ import Test.Hspec
 import Test.Hspec.Megaparsec.AdHoc
 import Test.QuickCheck
 import Text.Megaparsec.Pos
+import Text.Megaparsec.Types()
 
 #if !MIN_VERSION_base(4,8,0)
 import Data.Word (Word)

--- a/tests/Text/Megaparsec/PrimSpec.hs
+++ b/tests/Text/Megaparsec/PrimSpec.hs
@@ -33,6 +33,7 @@ import Text.Megaparsec.Combinator
 import Text.Megaparsec.Error
 import Text.Megaparsec.Pos
 import Text.Megaparsec.Prim
+import Text.Megaparsec.Types()
 import qualified Control.Monad.RWS.Lazy      as L
 import qualified Control.Monad.RWS.Strict    as S
 import qualified Control.Monad.State.Lazy    as L

--- a/tests/Text/Megaparsec/Types.hs
+++ b/tests/Text/Megaparsec/Types.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE CPP #-}
+{-# OPTIONS -fno-warn-orphans #-}
+
+module Text.Megaparsec.Types where
+
+import Test.QuickCheck
+import Text.Megaparsec.Error
+import Text.Megaparsec.Pos
+import Text.Megaparsec.Prim
+
+instance (Arbitrary t, Ord t, Arbitrary e, Ord e)
+    => Arbitrary (ParseError t e) where
+  arbitrary = ParseError
+#if MIN_VERSION_QuickCheck(2,9,0)
+    <$> arbitrary
+#else
+    <$> (NE.fromList . getNonEmpty <$> arbitrary)
+#endif
+#if MIN_VERSION_QuickCheck(2,8,2)
+    <*> arbitrary
+    <*> arbitrary
+    <*> arbitrary
+#else
+    <*> (E.fromList <$> arbitrary)
+    <*> (E.fromList <$> arbitrary)
+    <*> (E.fromList <$> arbitrary)
+#endif
+
+instance Arbitrary t => Arbitrary (ErrorItem t) where
+  arbitrary = oneof
+    [
+#if !MIN_VERSION_QuickCheck(2,9,0)
+      Tokens <$> (NE.fromList . getNonEmpty <$> arbitrary)
+    , Label  <$> (NE.fromList . getNonEmpty <$> arbitrary)
+#else
+      Tokens <$> arbitrary
+    , Label  <$> arbitrary
+#endif
+    , return EndOfInput ]
+
+instance Arbitrary Pos where
+  arbitrary = unsafePos <$> (getSmall <$> arbitrary `suchThat` (> 0))
+
+instance Arbitrary SourcePos where
+  arbitrary = SourcePos
+    <$> sized (\n -> do
+          k <- choose (0, n `div` 2)
+          vectorOf k arbitrary)
+    <*> (unsafePos <$> choose (1, 1000))
+    <*> (unsafePos <$> choose (1,  100))
+
+instance Arbitrary Dec where
+  arbitrary = oneof
+    [ sized (\n -> do
+        k <- choose (0, n `div` 2)
+        DecFail <$> vectorOf k arbitrary)
+    , DecIndentation <$> arbitrary <*> arbitrary <*> arbitrary ]
+
+instance Arbitrary a => Arbitrary (State a) where
+  arbitrary = State
+    <$> arbitrary
+    <*>
+#if !MIN_VERSION_QuickCheck(2,9,0)
+      (NE.fromList . getNonEmpty <$> arbitrary)
+#else
+      arbitrary
+#endif
+    <*> choose (1, 10000)
+    <*> (unsafePos <$> choose (1, 20))


### PR DESCRIPTION
I was checking out the dep graph of a library of mine which uses Megaparsec:

![deps](https://user-images.githubusercontent.com/229679/27114751-9e240ec6-507a-11e7-9df6-97ccd73dfd92.jpg)

Seeing `QuickCheck` in there as a build-dep for the library struck me as odd. I figured it might be `Arbitrary` instances, and it was, so I did this quick PR to move them out (as orphans) into the test suite. This reduces the dep burden on people who use megaparsec, as there are some QC-only transitive deps that are pulled in by it.

The module I added might not have the best name. Would `Instances` or `Orphans` be better?