### PR TITLE
Add a MonadFix ParsecT instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 * More lightweight dependency tree, dropped `exceptions` and `QuickCheck`
   dependencies.
 
+* Added a `MonadFix` instance for `ParsecT`
+
 ## Megaparsec 5.3.1
 
 * Various updates to the docs.

--- a/Text/Megaparsec.hs
+++ b/Text/Megaparsec.hs
@@ -400,6 +400,14 @@ pPlus m n = ParsecT $ \s cok cerr eok eerr ->
   in unParser m s cok cerr eok meerr
 {-# INLINE pPlus #-}
 
+instance (Stream s, MonadFix m) => MonadFix (ParsecT e s m) where
+  mfix f = mkPT $ \s -> mfix $ \(~(Reply _ _ result)) -> do
+    let
+      a = case result of
+        OK a' -> a'
+        Error _ -> error "mfix ParsecT"
+    runParsecT (f a) s
+
 -- | From two states, return the one with the greater number of processed
 -- tokens. If the numbers of processed tokens are equal, prefer the second
 -- state.


### PR DESCRIPTION
Example usage:

``` haskell
{-# LANGUAGE RecursiveDo, TypeApplications #-}
import Text.Megaparsec
import Text.Megaparsec.Char
import Control.Monad.Fix
import Data.Void

withRange
  :: (MonadParsec e s m, MonadFix m)
  => ((SourcePos,SourcePos) -> m a)
  -> m a
withRange f = do
  Just pos1 <- getNextTokenPosition
  rec
    r <- f (pos1, pos2)
    pos2 <- getPosition
  return r

main = do
  parseTest @Void (withRange $ \pp -> (,) pp <$> string "ab") "abcd"
```