### PR TITLE
Speed-up numeric parsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
  - travis_wait 60 cabal build
  - cabal test --show-details=always --test-option=--qc-max-success=1000
  - cabal sdist
- - cabal haddock | grep "100%" | wc -l | grep "10"
+ - cabal haddock | grep "100%" | wc -l | grep "11"
 
 after_script:
  - export PATH=~/.cabal/bin:$PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@
   to `Text.Megaparsec.Stream`. Generic combinators are now re-exported from
   the `Control.Applicative.Combinators` from the package
   `parser-combinators`. Just import `Text.Megaparsec` and you should be OK.
-  Then add `Text.Megaparsec.Char` if you are working with a stream of
-  `Char`s or `Text.Megaparsec.Byte` if you intend to parse binary data, then
-  add qualified modules you need (permutation parsing, lexing, expression
-  parsing, etc.).
+  Add `Text.Megaparsec.Char` if you are working with a stream of `Char`s or
+  `Text.Megaparsec.Byte` if you intend to parse binary data, then add
+  qualified modules you need (permutation parsing, lexing, expression
+  parsing, etc.). `Text.Megaparsec.Lexer` was renamed to
+  `Text.Megaparec.Char.Lexer` because many functions in it has the `Token s
+  ~ Char` constraint. There is also `Text.Megaparsec.Byte.Lexer` now,
+  although it has fewer functions.
 
 * Dropped per-stream modules, the `Parser` type synonym is to be defined
   manually by user.
@@ -43,9 +46,10 @@
 * Removed the `ErrorComponent` type class, added `ErrorFancy` instead.
   `ErrorFancy` is a sum type which can represent `fail` messages, incorrect
   indentation, and custom data (we use `Void` for that by default to
-  “disable” it). This is better than the type class-based approach because
+  “disable” it). This is better than the typeclass-based approach because
   every instance of `ErrorComponent` needed to have constructors for `fail`
-  and indentation massages anyway, leading to duplication of code.
+  and indentation massages anyway, leading to duplication of code (for
+  example for parse error component rendering).
 
 * Added `Functor` instances for `ErrorItem` and `ErrorFancy`.
 
@@ -58,9 +62,9 @@
   readable form only as standalone tokens.
 
 * Added `Text.Megaparsec.Error.Builder` module to help construct
-  `ParseError`s easily. Useful for testing and debugging, previously we had
-  something like that in the `hspec-megaparsec` package, but it does not
-  hurt to ship it with the library.
+  `ParseError`s easily. It is useful for testing and debugging. Previously
+  we had something like that in the `hspec-megaparsec` package, but it does
+  not hurt to ship it with the library.
 
 ### Stream
 
@@ -93,8 +97,24 @@
   requires at least one space character to be present to succeed.
 
 * Added new module `Text.Megaparsec.Byte`, which is similar to
-  `Text.Megaparsec.Char`, but target token type is `Word8` instead of
-  `Char`.
+  `Text.Megaparsec.Char`, but for token streams of the type `Word8` instead
+  of `Char`.
+
+* `integer` was dropped from `Text.Megaparec.Char.Lexer`. Use `decimal`
+  instead.
+
+* `number` was dropped from `Text.Megaparec.Char.Lexer`. Use `scientific`
+  instead.
+
+* `decimal`, `octal`, and `hexadecimal` are now polymorphic in their return
+  type and can be used to parse any instances of `Integral`.
+
+* `float` is now polymorphic in its return type and can be used to parse any
+  instance of `RealFloat`.
+
+* Added new module `Text.Megaparsec.Byte.Lexer`, which provides some
+  functions (white space and numeric helpers) from
+  `Text.Megaparsec.Char.Lexer` for streams with token type `Word8`.
 
 ## Megaparsec 5.3.1
 

--- a/Text/Megaparsec.hs
+++ b/Text/Megaparsec.hs
@@ -121,6 +121,9 @@ import Data.Set (Set)
 import Data.Typeable (Typeable)
 import Debug.Trace
 import GHC.Generics
+import Text.Megaparsec.Error
+import Text.Megaparsec.Pos
+import Text.Megaparsec.Stream
 import qualified Control.Applicative               as A
 import qualified Control.Monad.Fail                as Fail
 import qualified Control.Monad.RWS.Lazy            as L
@@ -132,10 +135,6 @@ import qualified Control.Monad.Trans.Writer.Lazy   as L
 import qualified Control.Monad.Trans.Writer.Strict as S
 import qualified Data.List.NonEmpty                as NE
 import qualified Data.Set                          as E
-
-import Text.Megaparsec.Error
-import Text.Megaparsec.Pos
-import Text.Megaparsec.Stream
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative

--- a/Text/Megaparsec/Byte.hs
+++ b/Text/Megaparsec/Byte.hs
@@ -53,9 +53,8 @@ import Data.Functor (void)
 import Data.Maybe (fromMaybe)
 import Data.Proxy
 import Data.Word (Word8)
-import qualified Text.Megaparsec.Char as C
-
 import Text.Megaparsec
+import qualified Text.Megaparsec.Char as C
 
 ----------------------------------------------------------------------------
 -- Simple parsers

--- a/Text/Megaparsec/Byte/Lexer.hs
+++ b/Text/Megaparsec/Byte/Lexer.hs
@@ -184,7 +184,7 @@ scientific = do
     return (mkNum xs, negate $ chunkLength pxy xs)
   e <- option e' $ do
     void (char' 101)
-    (`subtract` e') <$> signed (return ()) decimal_
+    (+ e') <$> signed (return ()) decimal_
   return (Sci.scientific c e)
 {-# INLINEABLE scientific #-}
 

--- a/Text/Megaparsec/Byte/Lexer.hs
+++ b/Text/Megaparsec/Byte/Lexer.hs
@@ -1,0 +1,183 @@
+-- |
+-- Module      :  Text.Megaparsec.Byte.Lexer
+-- Copyright   :  © 2015–2017 Megaparsec contributors
+-- License     :  FreeBSD
+--
+-- Maintainer  :  Mark Karpov <markkarpov92@gmail.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Stripped-down version of "Text.Megaparsec.Char.Lexer" for streams of
+-- bytes.
+
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+module Text.Megaparsec.Byte.Lexer
+  ( -- * White space
+    C.space
+  , C.lexeme
+  , C.symbol
+  , C.symbol'
+    -- * Numbers
+  , decimal
+  , octal
+  , hexadecimal
+  , scientific
+  , float
+  , signed )
+where
+
+import Data.Functor (void)
+import Data.List (foldl')
+import Data.Proxy
+import Data.Scientific (Scientific)
+import Data.Word (Word8)
+import Text.Megaparsec
+import Text.Megaparsec.Byte
+import qualified Data.Scientific            as Sci
+import qualified Text.Megaparsec.Char.Lexer as C
+
+----------------------------------------------------------------------------
+-- Numbers
+
+-- | Parse an integer in decimal representation according to the format of
+-- integer literals described in the Haskell report.
+--
+-- If you need to parse signed integers, see 'signed' combinator.
+
+decimal
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Integral a)
+  => m a
+decimal = decimal_ <?> "integer"
+{-# INLINEABLE decimal #-}
+
+-- | A non-public helper to parse decimal integers.
+
+decimal_
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Integral a)
+  => m a
+decimal_ = mkNum <$> takeWhile1P (Just "digit") isDigit
+  where
+    mkNum    = foldl' step 0 . chunkToTokens (Proxy :: Proxy s)
+    step a w = a * 10 + fromIntegral (w - 48)
+
+-- | Parse an integer in octal representation. Representation of octal
+-- number is expected to be according to the Haskell report except for the
+-- fact that this parser doesn't parse “0o” or “0O” prefix. It is a
+-- responsibility of the programmer to parse correct prefix before parsing
+-- the number itself.
+--
+-- For example you can make it conform to the Haskell report like this:
+--
+-- > octal = char '0' >> char' 'o' >> L.octal
+
+octal
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Integral a)
+  => m a
+octal = mkNum
+  <$> takeWhile1P Nothing isOctDigit
+  <?> "octal integer"
+  where
+    mkNum        = foldl' step 0 . chunkToTokens (Proxy :: Proxy s)
+    step a w     = a * 8 + fromIntegral (w - 48)
+    isOctDigit w = w - 48 < 8
+{-# INLINEABLE octal #-}
+
+-- | Parse an integer in hexadecimal representation. Representation of
+-- hexadecimal number is expected to be according to the Haskell report
+-- except for the fact that this parser doesn't parse “0x” or “0X” prefix.
+-- It is a responsibility of the programmer to parse correct prefix before
+-- parsing the number itself.
+--
+-- For example you can make it conform to the Haskell report like this:
+--
+-- > hexadecimal = char '0' >> char' 'x' >> L.hexadecimal
+
+hexadecimal
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Integral a)
+  => m a
+hexadecimal = mkNum
+  <$> takeWhile1P Nothing isHexDigit
+  <?> "hexadecimal integer"
+  where
+    mkNum        = foldl' step 0 . chunkToTokens (Proxy :: Proxy s)
+    step a w
+      | w >= 48 && w <= 57 = a * 16 + fromIntegral (w - 48)
+      | w >= 97            = a * 16 + fromIntegral (w - 87)
+      | otherwise          = a * 16 + fromIntegral (w - 55)
+    isHexDigit w =
+      (w >= 48 && w <= 57)  ||
+      (w >= 97 && w <= 102) ||
+      (w >= 65 && w <= 70)
+{-# INLINEABLE hexadecimal #-}
+
+-- | Parse a floating point value as a 'Scientific' number. 'Scientific' is
+-- great for parsing of arbitrary precision numbers coming from an untrusted
+-- source. See documentation in "Data.Scientific" for more information.
+--
+-- The parser can be used to use integers or floating point values. Use
+-- functions like 'Data.Scientific.floatingOrInteger' from "Data.Scientific"
+-- to test and extract integer or real values.
+--
+-- This function does not parse sign, if you need to parse signed numbers,
+-- see 'signed'.
+
+scientific
+  :: forall e s m. (MonadParsec e s m, Token s ~ Word8)
+  => m Scientific
+scientific = do
+  let pxy = Proxy :: Proxy s
+  c' <- decimal_
+  (c, e') <- option (c', 0) $ do
+    void (char 46)
+    xs <- takeWhile1P (Just "digit") isDigit
+    let mkNum    = foldl' step c' . chunkToTokens pxy
+        step a w = a * 10 + fromIntegral (w - 48)
+    return (mkNum xs, negate $ chunkLength pxy xs)
+  e <- option e' $ do
+    void (char' 101)
+    (`subtract` e') <$> signed (return ()) decimal_
+  return (Sci.scientific c e)
+{-# INLINEABLE scientific #-}
+
+-- | Parse a floating point number without sign. This is a simple shortcut
+-- defined as:
+--
+-- > float = toRealFloat <$> scientific
+--
+-- This function does not parse sign, if you need to parse signed numbers,
+-- see 'signed'.
+
+float :: (MonadParsec e s m, Token s ~ Word8, RealFloat a) => m a
+float = Sci.toRealFloat <$> scientific
+{-# INLINEABLE float #-}
+
+-- | @'signed' space p@ parser parses an optional sign, then if there is a
+-- sign it will consume optional white space (using @space@ parser), then it
+-- runs parser @p@ which should return a number. Sign of the number is
+-- changed according to previously parsed sign.
+--
+-- For example, to parse signed integer you can write:
+--
+-- > lexeme        = L.lexeme spaceConsumer
+-- > integer       = lexeme L.integer
+-- > signedInteger = L.signed spaceConsumer integer
+
+signed :: (MonadParsec e s m, Token s ~ Word8, Num a)
+  => m ()              -- ^ How to consume white space after the sign
+  -> m a               -- ^ How to parse the number itself
+  -> m a               -- ^ Parser for signed numbers
+signed spc p = ($) <$> option id (C.lexeme spc sign) <*> p
+  where
+    sign = (char 43 *> return id) <|> (char 45 *> return negate)
+{-# INLINEABLE signed #-}
+
+----------------------------------------------------------------------------
+-- Helpers
+
+-- | A fast predicate to check if given 'Word8' is a digit in ASCII.
+
+isDigit :: Word8 -> Bool
+isDigit w = w - 48 < 10
+{-# INLINE isDigit #-}

--- a/Text/Megaparsec/Byte/Lexer.hs
+++ b/Text/Megaparsec/Byte/Lexer.hs
@@ -164,7 +164,7 @@ hexadecimal = mkNum
 -- great for parsing of arbitrary precision numbers coming from an untrusted
 -- source. See documentation in "Data.Scientific" for more information.
 --
--- The parser can be used to use integers or floating point values. Use
+-- The parser can be used to parse integers or floating point values. Use
 -- functions like 'Data.Scientific.floatingOrInteger' from "Data.Scientific"
 -- to test and extract integer or real values.
 --
@@ -189,10 +189,14 @@ scientific = do
   return (Sci.scientific c e)
 {-# INLINEABLE scientific #-}
 
--- | Parse a floating point number without sign. This is a simple shortcut
--- defined as:
+-- | Parse a floating point number without sign. There are differences
+-- between the syntax for floating point literals described in the Haskell
+-- report and what this function accepts. In particular, it does not quire
+-- fractional part and accepts inputs like @\"3\"@ returning @3.0@.
 --
--- > float = toRealFloat <$> scientific
+-- This is a simple short-cut defined as:
+--
+-- > float = Sci.toRealFloat <$> scientific <?> "floating point number"
 --
 -- This function does not parse sign, if you need to parse signed numbers,
 -- see 'signed'.
@@ -209,7 +213,7 @@ float = Sci.toRealFloat <$> scientific <?> "floating point number"
 -- For example, to parse signed integer you can write:
 --
 -- > lexeme        = L.lexeme spaceConsumer
--- > integer       = lexeme L.integer
+-- > integer       = lexeme L.decimal
 -- > signedInteger = L.signed spaceConsumer integer
 
 signed :: (MonadParsec e s m, Token s ~ Word8, Num a)

--- a/Text/Megaparsec/Byte/Lexer.hs
+++ b/Text/Megaparsec/Byte/Lexer.hs
@@ -31,6 +31,7 @@ module Text.Megaparsec.Byte.Lexer
   , signed )
 where
 
+import Control.Applicative
 import Data.Functor (void)
 import Data.List (foldl')
 import Data.Proxy
@@ -59,7 +60,7 @@ skipLineComment prefix =
 -- | @'skipBlockComment' start end@ skips non-nested block comment starting
 -- with @start@ and ending with @end@.
 
-skipBlockComment :: (MonadParsec e s m, Token s ~ Char)
+skipBlockComment :: (MonadParsec e s m, Token s ~ Word8)
   => Tokens s          -- ^ Start of block comment
   -> Tokens s          -- ^ End of block comment
   -> m ()
@@ -74,7 +75,7 @@ skipBlockComment start end = p >> void (manyTill anyChar n)
 --
 -- @since 5.0.0
 
-skipBlockCommentNested :: (MonadParsec e s m, Token s ~ Char)
+skipBlockCommentNested :: (MonadParsec e s m, Token s ~ Word8)
   => Tokens s          -- ^ Start of block comment
   -> Tokens s          -- ^ End of block comment
   -> m ()
@@ -197,7 +198,7 @@ scientific = do
 -- see 'signed'.
 
 float :: (MonadParsec e s m, Token s ~ Word8, RealFloat a) => m a
-float = Sci.toRealFloat <$> scientific
+float = Sci.toRealFloat <$> scientific <?> "floating point number"
 {-# INLINEABLE float #-}
 
 -- | @'signed' space p@ parser parses an optional sign, then if there is a

--- a/Text/Megaparsec/Char.hs
+++ b/Text/Megaparsec/Char.hs
@@ -64,10 +64,9 @@ import Data.Function (on)
 import Data.Functor (void)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Proxy
+import Text.Megaparsec
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Set             as E
-
-import Text.Megaparsec
 
 #if !MIN_VERSION_base(4,8,0)
 import Data.Foldable (Foldable (), elem, notElem)

--- a/Text/Megaparsec/Char/Lexer.hs
+++ b/Text/Megaparsec/Char/Lexer.hs
@@ -504,6 +504,9 @@ scientific = do
 --
 -- This function does not parse sign, if you need to parse signed numbers,
 -- see 'signed'.
+--
+-- __Note__: before version 6.0.0 the function returned 'Double', i.e. it
+-- wasn't polymorphic in its return type.
 
 float :: (MonadParsec e s m, Token s ~ Char, RealFloat a) => m a
 float = Sci.toRealFloat <$> scientific <?> "floating point number"

--- a/Text/Megaparsec/Char/Lexer.hs
+++ b/Text/Megaparsec/Char/Lexer.hs
@@ -485,17 +485,20 @@ scientific
 scientific = do
   let pxy = Proxy :: Proxy s
   c' <- decimal_
-  (c, e') <- option (c', 0) $ do
+  SP c e' <- option (SP c' 0) $ do
     void (C.char '.')
-    xs <- takeWhile1P (Just "digit") Char.isDigit
-    let mkNum    = foldl' step c' . chunkToTokens pxy
-        step a c = a * 10 + fromIntegral (Char.digitToInt c)
-    return (mkNum xs, negate $ chunkLength pxy xs)
+    let mkNum    = foldl' step (SP c' 0) . chunkToTokens pxy
+        step (SP a e') c = SP
+          (a * 10 + fromIntegral (Char.digitToInt c))
+          (e' - 1)
+    mkNum <$> takeWhile1P (Just "digit") Char.isDigit
   e <- option e' $ do
     void (C.char' 'e')
     (+ e') <$> signed (return ()) decimal_
   return (Sci.scientific c e)
 {-# INLINEABLE scientific #-}
+
+data SP = SP !Integer {-# UNPACK #-} !Int
 
 -- | Parse a floating point number without sign. There are differences
 -- between the syntax for floating point literals described in the Haskell

--- a/Text/Megaparsec/Char/Lexer.hs
+++ b/Text/Megaparsec/Char/Lexer.hs
@@ -113,7 +113,7 @@ space ch line block = hidden . skipMany $ choice [ch, line, block]
 -- and use the resulting function to wrap parsers for every lexeme.
 --
 -- > lexeme  = L.lexeme spaceConsumer
--- > integer = lexeme L.integer
+-- > integer = lexeme L.decimal
 
 lexeme :: MonadParsec e s m
   => m ()              -- ^ How to consume white space after lexeme
@@ -470,7 +470,7 @@ hexadecimal = mkNum
 -- great for parsing of arbitrary precision numbers coming from an untrusted
 -- source. See documentation in "Data.Scientific" for more information.
 --
--- The parser can be used to use integers or floating point values. Use
+-- The parser can be used to parse integers or floating point values. Use
 -- functions like 'Data.Scientific.floatingOrInteger' from "Data.Scientific"
 -- to test and extract integer or real values.
 --
@@ -497,10 +497,14 @@ scientific = do
   return (Sci.scientific c e)
 {-# INLINEABLE scientific #-}
 
--- | Parse a floating point number without sign. This is a simple shortcut
--- defined as:
+-- | Parse a floating point number without sign. There are differences
+-- between the syntax for floating point literals described in the Haskell
+-- report and what this function accepts. In particular, it does not quire
+-- fractional part and accepts inputs like @\"3\"@ returning @3.0@.
 --
--- > float = toRealFloat <$> scientific
+-- This is a simple short-cut defined as:
+--
+-- > float = Sci.toRealFloat <$> scientific <?> "floating point number"
 --
 -- This function does not parse sign, if you need to parse signed numbers,
 -- see 'signed'.
@@ -520,7 +524,7 @@ float = Sci.toRealFloat <$> scientific <?> "floating point number"
 -- For example, to parse signed integer you can write:
 --
 -- > lexeme        = L.lexeme spaceConsumer
--- > integer       = lexeme L.integer
+-- > integer       = lexeme L.decimal
 -- > signedInteger = L.signed spaceConsumer integer
 
 signed :: (MonadParsec e s m, Token s ~ Char, Num a)

--- a/Text/Megaparsec/Char/Lexer.hs
+++ b/Text/Megaparsec/Char/Lexer.hs
@@ -493,7 +493,7 @@ scientific = do
     return (mkNum xs, negate $ chunkLength pxy xs)
   e <- option e' $ do
     void (C.char' 'e')
-    (`subtract` e') <$> signed (return ()) decimal_
+    (+ e') <$> signed (return ()) decimal_
   return (Sci.scientific c e)
 {-# INLINEABLE scientific #-}
 

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -48,10 +48,9 @@ import Data.Void
 import Data.Word (Word8)
 import GHC.Generics
 import Prelude hiding (concat)
+import Text.Megaparsec.Pos
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set           as E
-
-import Text.Megaparsec.Pos
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative

--- a/bench/memory/Main.hs
+++ b/bench/memory/Main.hs
@@ -10,7 +10,8 @@ import Data.Void
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import Weigh
-import qualified Data.Text as T
+import qualified Data.Text                  as T
+import qualified Text.Megaparsec.Char.Lexer as L
 
 -- | The type of parser that consumes 'String's.
 
@@ -40,6 +41,10 @@ main = mainWith $ do
   bparser "skipSomeTill" manyAsB (const $ skipSomeTill (char 'a') (char 'b'))
   bparser "takeWhileP" manyAs (const $ takeWhileP Nothing (== 'a'))
   bparser "takeWhile1P" manyAs (const $ takeWhile1P Nothing (== 'a'))
+  bparser "decimal" mkInt (const (L.decimal :: Parser Integer))
+  bparser "octal" mkInt (const (L.octal :: Parser Integer))
+  bparser "hexadecimal" mkInt (const (L.hexadecimal :: Parser Integer))
+  bparser "scientific" mkInt (const L.scientific)
 
 -- | Perform a series of measurements with the same parser.
 
@@ -85,3 +90,9 @@ manyAsB' n = replicate n 'a' ++ "b"
 
 manyAbs' :: Int -> Text
 manyAbs' n = T.take (if even n then n else n + 1) (T.replicate n "ab")
+
+-- | Render an 'Integer' with the number of digits linearly dependent on the
+-- argument.
+
+mkInt :: Int -> Text
+mkInt n = (T.pack . show) ((10 :: Integer) ^ (n `quot` 100))

--- a/bench/speed/Main.hs
+++ b/bench/speed/Main.hs
@@ -9,7 +9,8 @@ import Data.Text (Text)
 import Data.Void
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import qualified Data.Text as T
+import qualified Data.Text                  as T
+import qualified Text.Megaparsec.Char.Lexer as L
 
 -- | The type of parser that consumes 'String's.
 
@@ -38,6 +39,10 @@ main = defaultMain
   , bparser "skipSomeTill" manyAsB (const $ skipSomeTill (char 'a') (char 'b'))
   , bparser "takeWhileP" manyAs (const $ takeWhileP Nothing (== 'a'))
   , bparser "takeWhile1P" manyAs (const $ takeWhile1P Nothing (== 'a'))
+  , bparser "decimal" mkInt (const (L.decimal :: Parser Integer))
+  , bparser "octal" mkInt (const (L.octal :: Parser Integer))
+  , bparser "hexadecimal" mkInt (const (L.hexadecimal :: Parser Integer))
+  , bparser "scientific" mkInt (const L.scientific)
   ]
 
 -- | Perform a series to measurements with the same parser.
@@ -84,3 +89,9 @@ manyAsB' n = replicate n 'a' ++ "b"
 
 manyAbs' :: Int -> Text
 manyAbs' n = T.take (if even n then n else n + 1) (T.replicate n "ab")
+
+-- | Render an 'Integer' with the number of digits linearly dependent on the
+-- argument.
+
+mkInt :: Int -> Text
+mkInt n = (T.pack . show) ((10 :: Integer) ^ (n `quot` 100))

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -50,6 +50,7 @@ library
     build-depends:    void         == 0.7.*
   exposed-modules:    Text.Megaparsec
                     , Text.Megaparsec.Byte
+                    , Text.Megaparsec.Byte.Lexer
                     , Text.Megaparsec.Char
                     , Text.Megaparsec.Char.Lexer
                     , Text.Megaparsec.Error

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -76,6 +76,7 @@ test-suite tests
   other-modules:      Control.Applicative.CombinatorsSpec
                     , Test.Hspec.Megaparsec
                     , Test.Hspec.Megaparsec.AdHoc
+                    , Text.Megaparsec.Byte.LexerSpec
                     , Text.Megaparsec.ByteSpec
                     , Text.Megaparsec.Char.LexerSpec
                     , Text.Megaparsec.CharSpec

--- a/tests/Test/Hspec/Megaparsec/AdHoc.hs
+++ b/tests/Test/Hspec/Megaparsec/AdHoc.hs
@@ -233,3 +233,8 @@ instance Arbitrary B.ByteString where
 
 instance Arbitrary BL.ByteString where
   arbitrary = BL.pack <$> arbitrary
+
+#if MIN_VERSION_QuickCheck(2,10,0)
+instance Arbitrary a => Arbitrary (NonEmpty a) where
+  arbitrary = NE.fromList <$> (arbitrary `suchThat` (not . null))
+#endif

--- a/tests/Text/Megaparsec/Byte/LexerSpec.hs
+++ b/tests/Text/Megaparsec/Byte/LexerSpec.hs
@@ -1,0 +1,6 @@
+module Text.Megaparsec.Byte.LexerSpec (spec) where
+
+import Test.Hspec
+
+spec :: Spec
+spec = return ()

--- a/tests/Text/Megaparsec/Byte/LexerSpec.hs
+++ b/tests/Text/Megaparsec/Byte/LexerSpec.hs
@@ -4,6 +4,7 @@ module Text.Megaparsec.Byte.LexerSpec (spec) where
 
 import Control.Applicative
 import Data.ByteString (ByteString)
+import Data.Char (toUpper)
 import Data.Monoid ((<>))
 import Data.Scientific (Scientific, fromFloatDigits)
 import Data.Void
@@ -88,6 +89,14 @@ spec = do
           let p = hexadecimal :: Parser Integer
               n = getNonNegative n'
               s = B8.pack (showHex n "")
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "when stream begins with hexadecimal digits (uppercase)" $
+      it "they are parsed as an integer" $
+        property $ \n' -> do
+          let p = hexadecimal :: Parser Integer
+              n = getNonNegative n'
+              s = B8.pack (toUpper <$> showHex n "")
           prs  p s `shouldParse` n
           prs' p s `succeedsLeaving` ""
     context "when stream does not begin with hexadecimal digits" $

--- a/tests/Text/Megaparsec/Byte/LexerSpec.hs
+++ b/tests/Text/Megaparsec/Byte/LexerSpec.hs
@@ -1,6 +1,233 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Text.Megaparsec.Byte.LexerSpec (spec) where
 
+import Control.Applicative
+import Data.ByteString (ByteString)
+import Data.Monoid ((<>))
+import Data.Scientific (Scientific, fromFloatDigits)
+import Data.Void
+import Data.Word (Word8)
+import Numeric (showInt, showHex, showOct)
 import Test.Hspec
+import Test.Hspec.Megaparsec
+import Test.QuickCheck
+import Text.Megaparsec
+import Text.Megaparsec.Byte.Lexer
+import qualified Data.ByteString       as B
+import qualified Data.ByteString.Char8 as B8
+import qualified Text.Megaparsec.Byte  as B
+
+type Parser = Parsec Void ByteString
 
 spec :: Spec
-spec = return ()
+spec = do
+
+  describe "skipLineComment" $
+    context "when there is no newline at the end of line" $
+      it "is picked up successfully" $ do
+        let p = space B.space1 (skipLineComment "//") empty <* eof
+            s = "  // this line comment doesn't have a newline at the end "
+        prs  p s `shouldParse` ()
+        prs' p s `succeedsLeaving` ""
+
+  describe "skipBlockCommentNested" $
+    context "when it runs into nested block comments" $
+      it "parses them all right" $ do
+        let p = space B.space1 empty
+              (skipBlockCommentNested "/*" "*/") <* eof
+            s = " /* foo bar /* baz */ quux */ "
+        prs  p s `shouldParse` ()
+        prs' p s `succeedsLeaving` ""
+
+  describe "decimal" $ do
+    context "when stream begins with decimal digits" $
+      it "they are parsed as an integer" $
+        property $ \n' -> do
+          let p = decimal :: Parser Integer
+              n = getNonNegative n'
+              s = B8.pack (showInt n "")
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "when stream does not begin with decimal digits" $
+      it "signals correct parse error" $
+        property $ \a as -> not (isDigit a) ==> do
+          let p = decimal :: Parser Integer
+              s = B.pack (a : as)
+          prs  p s `shouldFailWith` err posI (utok a <> elabel "integer")
+    context "when stream is empty" $
+      it "signals correct parse error" $
+        prs (decimal :: Parser Integer) "" `shouldFailWith`
+          err posI (ueof <> elabel "integer")
+
+  describe "octal" $ do
+    context "when stream begins with octal digits" $
+      it "they are parsed as an integer" $
+        property $ \n' -> do
+          let p = octal :: Parser Integer
+              n = getNonNegative n'
+              s = B8.pack (showOct n "")
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "when stream does not begin with octal digits" $
+      it "signals correct parse error" $
+        property $ \a as -> not (isOctDigit a) ==> do
+          let p = octal :: Parser Integer
+              s = B.pack (a : as)
+          prs  p s `shouldFailWith`
+            err posI (utok a <> elabel "octal integer")
+    context "when stream is empty" $
+      it "signals correct parse error" $
+        prs (octal :: Parser Integer) "" `shouldFailWith`
+          err posI (ueof <> elabel "octal integer")
+
+  describe "hexadecimal" $ do
+    context "when stream begins with hexadecimal digits" $
+      it "they are parsed as an integer" $
+        property $ \n' -> do
+          let p = hexadecimal :: Parser Integer
+              n = getNonNegative n'
+              s = B8.pack (showHex n "")
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "when stream does not begin with hexadecimal digits" $
+      it "signals correct parse error" $
+        property $ \a as -> not (isHexDigit a) ==> do
+          let p = hexadecimal :: Parser Integer
+              s = B.pack (a : as)
+          prs  p s `shouldFailWith`
+            err posI (utok a <> elabel "hexadecimal integer")
+    context "when stream is empty" $
+      it "signals correct parse error" $
+        prs (hexadecimal :: Parser Integer) "" `shouldFailWith`
+          err posI (ueof <> elabel "hexadecimal integer")
+
+  describe "float" $ do
+    context "when stream begins with a float" $
+      it "parses it" $
+        property $ \n' -> do
+          let p = float :: Parser Double
+              n = getNonNegative n'
+              s = B8.pack (show n)
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "when stream does not begin with a float" $
+      it "signals correct parse error" $
+        property $ \a as -> not (isDigit a) ==> do
+          let p = float :: Parser Double
+              s = B.pack (a : as)
+          prs  p s `shouldFailWith`
+            err posI (utok a <> elabel "floating point number")
+          prs' p s `failsLeaving` s
+    context "when stream begins with a decimal number" $
+      it "parses it" $
+        property $ \n' -> do
+          let p = float :: Parser Double
+              n = getNonNegative n'
+              s = B8.pack $ show (n :: Integer)
+          prs  p s `shouldParse` fromIntegral n
+          prs' p s `succeedsLeaving` ""
+    context "when stream is empty" $
+      it "signals correct parse error" $
+        prs (float :: Parser Double) "" `shouldFailWith`
+          err posI (ueof <> elabel "floating point number")
+    context "when there is float with exponent without explicit sign" $
+      it "parses it all right" $ do
+        let p = float :: Parser Double
+            s = "123e3"
+        prs  p s `shouldParse` 123e3
+        prs' p s `succeedsLeaving` ""
+
+  describe "scientific" $ do
+    context "when stream begins with a number" $
+      it "parses it" $
+        property $ \n' -> do
+          let p = scientific :: Parser Scientific
+              s = B8.pack $ either (show . getNonNegative) (show . getNonNegative)
+                (n' :: Either (NonNegative Integer) (NonNegative Double))
+          prs p s `shouldParse` case n' of
+            Left  x -> fromIntegral    (getNonNegative x)
+            Right x -> fromFloatDigits (getNonNegative x)
+          prs' p s `succeedsLeaving` ""
+    context "when stream is empty" $
+      it "signals correct parse error" $
+        prs (scientific :: Parser Scientific) "" `shouldFailWith`
+          err posI (ueof <> elabel "digit")
+
+  describe "signed" $ do
+    context "with integer" $
+      it "parses signed integers" $
+        property $ \n -> do
+          let p :: Parser Integer
+              p = signed (hidden B.space) decimal
+              s = B8.pack (show n)
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "with float" $
+      it "parses signed floats" $
+        property $ \n -> do
+          let p :: Parser Double
+              p = signed (hidden B.space) float
+              s = B8.pack (show n)
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "with scientific" $
+      it "parses singed scientific numbers" $
+        property $ \n -> do
+          let p = signed (hidden B.space) scientific
+              s = B8.pack $ either show show (n :: Either Integer Double)
+          prs p s `shouldParse` case n of
+            Left  x -> fromIntegral    x
+            Right x -> fromFloatDigits x
+    context "when number is prefixed with plus sign" $
+      it "parses the number" $
+        property $ \n' -> do
+          let p :: Parser Integer
+              p = signed (hidden B.space) decimal
+              n = getNonNegative n'
+              s = B8.pack ('+' : show n)
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "when number is prefixed with white space" $
+      it "signals correct parse error" $
+        property $ \n -> do
+          let p :: Parser Integer
+              p = signed (hidden B.space) decimal
+              s = B8.pack (' ' : show (n :: Integer))
+          prs  p s `shouldFailWith` err posI
+            (utok 32 <> etok 43 <> etok 45 <> elabel "integer")
+          prs' p s `failsLeaving` s
+    context "when there is white space between sign and digits" $
+      it "parses it all right" $ do
+        let p :: Parser Integer
+            p = signed (hidden B.space) decimal
+            s = "- 123"
+        prs  p s `shouldParse` (-123)
+        prs' p s `succeedsLeaving` ""
+
+----------------------------------------------------------------------------
+-- Helpers
+
+prs
+  :: Parser a          -- ^ Parser to run
+  -> ByteString        -- ^ Input for the parser
+  -> Either (ParseError Word8 Void) a -- ^ Result of parsing
+prs p = parse p ""
+
+prs'
+  :: Parser a          -- ^ Parser to run
+  -> ByteString        -- ^ Input for the parser
+  -> (State ByteString, Either (ParseError Word8 Void) a) -- ^ Result of parsing
+prs' p s = runParser' p (initialState s)
+
+isDigit :: Word8 -> Bool
+isDigit w = w - 48 < 10
+
+isOctDigit :: Word8 -> Bool
+isOctDigit w = w - 48 < 8
+
+isHexDigit :: Word8 -> Bool
+isHexDigit w =
+  (w >= 48 && w <= 57)  ||
+  (w >= 97 && w <= 102) ||
+  (w >= 65 && w <= 70)

--- a/tests/Text/Megaparsec/Byte/LexerSpec.hs
+++ b/tests/Text/Megaparsec/Byte/LexerSpec.hs
@@ -9,7 +9,7 @@ import Data.Monoid ((<>))
 import Data.Scientific (Scientific, fromFloatDigits)
 import Data.Void
 import Data.Word (Word8)
-import Numeric (showInt, showHex, showOct)
+import Numeric (showInt, showHex, showOct, showFFloatAlt)
 import Test.Hspec
 import Test.Hspec.Megaparsec
 import Test.QuickCheck
@@ -174,7 +174,7 @@ spec = do
       it "signals correct parse error" $
         property $ \(NonNegative n) -> do
           let p = scientific <* empty :: Parser Scientific
-              s = B8.pack (show (n :: Double))
+              s = B8.pack (showFFloatAlt Nothing (n :: Double) "")
           prs p s `shouldFailWith` err (posN (B.length s) s)
             (etok 69 <> etok 101 <> elabel "digit")
           prs' p s `failsLeaving` ""

--- a/tests/Text/Megaparsec/Char/LexerSpec.hs
+++ b/tests/Text/Megaparsec/Char/LexerSpec.hs
@@ -12,7 +12,7 @@ import Data.Char hiding (ord)
 import Data.List (isInfixOf)
 import Data.Maybe
 import Data.Monoid ((<>))
--- import Data.Scientific (fromFloatDigits)
+import Data.Scientific (Scientific, fromFloatDigits)
 import Data.Void (Void)
 import Numeric (showInt, showHex, showOct)
 import Test.Hspec
@@ -259,27 +259,6 @@ spec = do
         prs (decimal :: Parser Integer) "" `shouldFailWith`
           err posI (ueof <> elabel "integer")
 
-  describe "hexadecimal" $ do
-    context "when stream begins with hexadecimal digits" $
-      it "they are parsed as an integer" $
-        property $ \n' -> do
-          let p = hexadecimal :: Parser Integer
-              n = getNonNegative n'
-              s = showHex n ""
-          prs  p s `shouldParse` n
-          prs' p s `succeedsLeaving` ""
-    context "when stream does not begin with hexadecimal digits" $
-      it "signals correct parse error" $
-        property $ \a as -> not (isHexDigit a) ==> do
-          let p = hexadecimal :: Parser Integer
-              s = a : as
-          prs  p s `shouldFailWith`
-            err posI (utok a <> elabel "hexadecimal integer")
-    context "when stream is empty" $
-      it "signals correct parse error" $
-        prs (hexadecimal :: Parser Integer) "" `shouldFailWith`
-          err posI (ueof <> elabel "hexadecimal integer")
-
   describe "octal" $ do
     context "when stream begins with octal digits" $
       it "they are parsed as an integer" $
@@ -301,6 +280,27 @@ spec = do
         prs (octal :: Parser Integer) "" `shouldFailWith`
           err posI (ueof <> elabel "octal integer")
 
+  describe "hexadecimal" $ do
+    context "when stream begins with hexadecimal digits" $
+      it "they are parsed as an integer" $
+        property $ \n' -> do
+          let p = hexadecimal :: Parser Integer
+              n = getNonNegative n'
+              s = showHex n ""
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "when stream does not begin with hexadecimal digits" $
+      it "signals correct parse error" $
+        property $ \a as -> not (isHexDigit a) ==> do
+          let p = hexadecimal :: Parser Integer
+              s = a : as
+          prs  p s `shouldFailWith`
+            err posI (utok a <> elabel "hexadecimal integer")
+    context "when stream is empty" $
+      it "signals correct parse error" $
+        prs (hexadecimal :: Parser Integer) "" `shouldFailWith`
+          err posI (ueof <> elabel "hexadecimal integer")
+
   describe "float" $ do
     context "when stream begins with a float" $
       it "parses it" $
@@ -319,14 +319,13 @@ spec = do
             err posI (utok a <> elabel "floating point number")
           prs' p s `failsLeaving` s
     context "when stream begins with a decimal number" $
-      it "signals correct parse error" $
+      it "parses it" $
         property $ \n' -> do
           let p = float :: Parser Double
               n = getNonNegative n'
               s = show (n :: Integer)
-          prs  p s `shouldFailWith` err (posN (length s) s)
-            (ueof <> etok '.' <> etok 'E' <> etok 'e' <> elabel "digit")
-          prs' p s `failsLeaving` ""
+          prs  p s `shouldParse` fromIntegral n
+          prs' p s `succeedsLeaving` ""
     context "when stream is empty" $
       it "signals correct parse error" $
         prs (float :: Parser Double) "" `shouldFailWith`
@@ -338,67 +337,72 @@ spec = do
         prs  p s `shouldParse` 123e3
         prs' p s `succeedsLeaving` ""
 
-  -- describe "number" $ do
-  --   context "when stream begins with a number" $
-  --     it "parses it" $
-  --       property $ \n' -> do
-  --         let p = number
-  --             s = either (show . getNonNegative) (show . getNonNegative)
-  --               (n' :: Either (NonNegative Integer) (NonNegative Double))
-  --         prs p s `shouldParse` case n' of
-  --           Left  x -> fromIntegral    (getNonNegative x)
-  --           Right x -> fromFloatDigits (getNonNegative x)
-  --         prs' p s `succeedsLeaving` ""
-  --   context "when stream is empty" $
-  --     it "signals correct parse error" $
-  --       prs number "" `shouldFailWith`
-  --         err posI (ueof <> elabel "number")
+  describe "scientific" $ do
+    context "when stream begins with a number" $
+      it "parses it" $
+        property $ \n' -> do
+          let p = scientific :: Parser Scientific
+              s = either (show . getNonNegative) (show . getNonNegative)
+                (n' :: Either (NonNegative Integer) (NonNegative Double))
+          prs p s `shouldParse` case n' of
+            Left  x -> fromIntegral    (getNonNegative x)
+            Right x -> fromFloatDigits (getNonNegative x)
+          prs' p s `succeedsLeaving` ""
+    context "when stream is empty" $
+      it "signals correct parse error" $
+        prs (scientific :: Parser Scientific) "" `shouldFailWith`
+          err posI (ueof <> elabel "digit")
 
-  -- describe "signed" $ do
-  --   context "with integer" $
-  --     it "parses signed integers" $
-  --       property $ \n -> do
-  --         let p = signed (hidden C.space) integer
-  --             s = show n
-  --         prs  p s `shouldParse` n
-  --         prs' p s `succeedsLeaving` ""
-  --   context "with float" $
-  --     it "parses signed floats" $
-  --       property $ \n -> do
-  --         let p = signed (hidden C.space) float
-  --             s = show n
-  --         prs  p s `shouldParse` n
-  --         prs' p s `succeedsLeaving` ""
-  --   context "with number" $
-  --     it "parses singed numbers" $
-  --       property $ \n -> do
-  --         let p = signed (hidden C.space) number
-  --             s = either show show (n :: Either Integer Double)
-  --         prs p s `shouldParse` case n of
-  --           Left  x -> fromIntegral    x
-  --           Right x -> fromFloatDigits x
-  --   context "when number is prefixed with plus sign" $
-  --     it "parses the number" $
-  --       property $ \n' -> do
-  --         let p = signed (hidden C.space) integer
-  --             n = getNonNegative n'
-  --             s = '+' : show n
-  --         prs  p s `shouldParse` n
-  --         prs' p s `succeedsLeaving` ""
-  --   context "when number is prefixed with white space" $
-  --     it "signals correct parse error" $
-  --       property $ \n -> do
-  --         let p = signed (hidden C.space) integer
-  --             s = ' ' : show (n :: Integer)
-  --         prs  p s `shouldFailWith` err posI
-  --           (utok ' ' <> etok '+' <> etok '-' <> elabel "integer")
-  --         prs' p s `failsLeaving` s
-  --   context "when there is white space between sign and digits" $
-  --     it "parses it all right" $ do
-  --       let p = signed (hidden C.space) integer
-  --           s = "- 123"
-  --       prs  p s `shouldParse` (-123)
-  --       prs' p s `succeedsLeaving` ""
+  describe "signed" $ do
+    context "with integer" $
+      it "parses signed integers" $
+        property $ \n -> do
+          let p :: Parser Integer
+              p = signed (hidden C.space) decimal
+              s = show n
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "with float" $
+      it "parses signed floats" $
+        property $ \n -> do
+          let p :: Parser Double
+              p = signed (hidden C.space) float
+              s = show n
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "with scientific" $
+      it "parses singed scientific numbers" $
+        property $ \n -> do
+          let p = signed (hidden C.space) scientific
+              s = either show show (n :: Either Integer Double)
+          prs p s `shouldParse` case n of
+            Left  x -> fromIntegral    x
+            Right x -> fromFloatDigits x
+    context "when number is prefixed with plus sign" $
+      it "parses the number" $
+        property $ \n' -> do
+          let p :: Parser Integer
+              p = signed (hidden C.space) decimal
+              n = getNonNegative n'
+              s = '+' : show n
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "when number is prefixed with white space" $
+      it "signals correct parse error" $
+        property $ \n -> do
+          let p :: Parser Integer
+              p = signed (hidden C.space) decimal
+              s = ' ' : show (n :: Integer)
+          prs  p s `shouldFailWith` err posI
+            (utok ' ' <> etok '+' <> etok '-' <> elabel "integer")
+          prs' p s `failsLeaving` s
+    context "when there is white space between sign and digits" $
+      it "parses it all right" $ do
+        let p :: Parser Integer
+            p = signed (hidden C.space) decimal
+            s = "- 123"
+        prs  p s `shouldParse` (-123)
+        prs' p s `succeedsLeaving` ""
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/tests/Text/Megaparsec/Char/LexerSpec.hs
+++ b/tests/Text/Megaparsec/Char/LexerSpec.hs
@@ -12,7 +12,7 @@ import Data.Char hiding (ord)
 import Data.List (isInfixOf)
 import Data.Maybe
 import Data.Monoid ((<>))
-import Data.Scientific (fromFloatDigits)
+-- import Data.Scientific (fromFloatDigits)
 import Data.Void (Void)
 import Numeric (showInt, showHex, showOct)
 import Test.Hspec
@@ -239,31 +239,11 @@ spec = do
         let p = charLiteral
         prs p "" `shouldFailWith` err posI (ueof <> elabel "literal character")
 
-  describe "integer" $ do
-    context "when stream begins with decimal digits" $
-      it "they are parsed as an integer" $
-        property $ \n' -> do
-          let p = integer
-              n = getNonNegative n'
-              s = showInt n ""
-          prs  p s `shouldParse` n
-          prs' p s `succeedsLeaving` ""
-    context "when stream does not begin with decimal digits" $
-      it "signals correct parse error" $
-        property $ \a as -> not (isDigit a) ==> do
-          let p = integer
-              s = a : as
-          prs  p s `shouldFailWith` err posI (utok a <> elabel "integer")
-    context "when stream is empty" $
-      it "signals correct parse error" $
-        prs integer "" `shouldFailWith`
-          err posI (ueof <> elabel "integer")
-
   describe "decimal" $ do
     context "when stream begins with decimal digits" $
       it "they are parsed as an integer" $
         property $ \n' -> do
-          let p = decimal
+          let p = decimal :: Parser Integer
               n = getNonNegative n'
               s = showInt n ""
           prs  p s `shouldParse` n
@@ -271,19 +251,19 @@ spec = do
     context "when stream does not begin with decimal digits" $
       it "signals correct parse error" $
         property $ \a as -> not (isDigit a) ==> do
-          let p = decimal
+          let p = decimal :: Parser Integer
               s = a : as
-          prs  p s `shouldFailWith` err posI (utok a <> elabel "decimal integer")
+          prs  p s `shouldFailWith` err posI (utok a <> elabel "integer")
     context "when stream is empty" $
       it "signals correct parse error" $
-        prs decimal "" `shouldFailWith`
-          err posI (ueof <> elabel "decimal integer")
+        prs (decimal :: Parser Integer) "" `shouldFailWith`
+          err posI (ueof <> elabel "integer")
 
   describe "hexadecimal" $ do
     context "when stream begins with hexadecimal digits" $
       it "they are parsed as an integer" $
         property $ \n' -> do
-          let p = hexadecimal
+          let p = hexadecimal :: Parser Integer
               n = getNonNegative n'
               s = showHex n ""
           prs  p s `shouldParse` n
@@ -291,20 +271,20 @@ spec = do
     context "when stream does not begin with hexadecimal digits" $
       it "signals correct parse error" $
         property $ \a as -> not (isHexDigit a) ==> do
-          let p = hexadecimal
+          let p = hexadecimal :: Parser Integer
               s = a : as
           prs  p s `shouldFailWith`
             err posI (utok a <> elabel "hexadecimal integer")
     context "when stream is empty" $
       it "signals correct parse error" $
-        prs hexadecimal "" `shouldFailWith`
+        prs (hexadecimal :: Parser Integer) "" `shouldFailWith`
           err posI (ueof <> elabel "hexadecimal integer")
 
   describe "octal" $ do
     context "when stream begins with octal digits" $
       it "they are parsed as an integer" $
         property $ \n' -> do
-          let p = octal
+          let p = octal :: Parser Integer
               n = getNonNegative n'
               s = showOct n ""
           prs  p s `shouldParse` n
@@ -312,20 +292,20 @@ spec = do
     context "when stream does not begin with octal digits" $
       it "signals correct parse error" $
         property $ \a as -> not (isOctDigit a) ==> do
-          let p = octal
+          let p = octal :: Parser Integer
               s = a : as
           prs  p s `shouldFailWith`
             err posI (utok a <> elabel "octal integer")
     context "when stream is empty" $
       it "signals correct parse error" $
-        prs octal "" `shouldFailWith`
+        prs (octal :: Parser Integer) "" `shouldFailWith`
           err posI (ueof <> elabel "octal integer")
 
   describe "float" $ do
     context "when stream begins with a float" $
       it "parses it" $
         property $ \n' -> do
-          let p = float
+          let p = float :: Parser Double
               n = getNonNegative n'
               s = show n
           prs  p s `shouldParse` n
@@ -333,7 +313,7 @@ spec = do
     context "when stream does not begin with a float" $
       it "signals correct parse error" $
         property $ \a as -> not (isDigit a) ==> do
-          let p = float
+          let p = float :: Parser Double
               s = a : as
           prs  p s `shouldFailWith`
             err posI (utok a <> elabel "floating point number")
@@ -341,7 +321,7 @@ spec = do
     context "when stream begins with a decimal number" $
       it "signals correct parse error" $
         property $ \n' -> do
-          let p = float
+          let p = float :: Parser Double
               n = getNonNegative n'
               s = show (n :: Integer)
           prs  p s `shouldFailWith` err (posN (length s) s)
@@ -349,76 +329,76 @@ spec = do
           prs' p s `failsLeaving` ""
     context "when stream is empty" $
       it "signals correct parse error" $
-        prs float "" `shouldFailWith`
+        prs (float :: Parser Double) "" `shouldFailWith`
           err posI (ueof <> elabel "floating point number")
     context "when there is float with exponent without explicit sign" $
       it "parses it all right" $ do
-        let p = float
+        let p = float :: Parser Double
             s = "123e3"
         prs  p s `shouldParse` 123e3
         prs' p s `succeedsLeaving` ""
 
-  describe "number" $ do
-    context "when stream begins with a number" $
-      it "parses it" $
-        property $ \n' -> do
-          let p = number
-              s = either (show . getNonNegative) (show . getNonNegative)
-                (n' :: Either (NonNegative Integer) (NonNegative Double))
-          prs p s `shouldParse` case n' of
-            Left  x -> fromIntegral    (getNonNegative x)
-            Right x -> fromFloatDigits (getNonNegative x)
-          prs' p s `succeedsLeaving` ""
-    context "when stream is empty" $
-      it "signals correct parse error" $
-        prs number "" `shouldFailWith`
-          err posI (ueof <> elabel "number")
+  -- describe "number" $ do
+  --   context "when stream begins with a number" $
+  --     it "parses it" $
+  --       property $ \n' -> do
+  --         let p = number
+  --             s = either (show . getNonNegative) (show . getNonNegative)
+  --               (n' :: Either (NonNegative Integer) (NonNegative Double))
+  --         prs p s `shouldParse` case n' of
+  --           Left  x -> fromIntegral    (getNonNegative x)
+  --           Right x -> fromFloatDigits (getNonNegative x)
+  --         prs' p s `succeedsLeaving` ""
+  --   context "when stream is empty" $
+  --     it "signals correct parse error" $
+  --       prs number "" `shouldFailWith`
+  --         err posI (ueof <> elabel "number")
 
-  describe "signed" $ do
-    context "with integer" $
-      it "parses signed integers" $
-        property $ \n -> do
-          let p = signed (hidden C.space) integer
-              s = show n
-          prs  p s `shouldParse` n
-          prs' p s `succeedsLeaving` ""
-    context "with float" $
-      it "parses signed floats" $
-        property $ \n -> do
-          let p = signed (hidden C.space) float
-              s = show n
-          prs  p s `shouldParse` n
-          prs' p s `succeedsLeaving` ""
-    context "with number" $
-      it "parses singed numbers" $
-        property $ \n -> do
-          let p = signed (hidden C.space) number
-              s = either show show (n :: Either Integer Double)
-          prs p s `shouldParse` case n of
-            Left  x -> fromIntegral    x
-            Right x -> fromFloatDigits x
-    context "when number is prefixed with plus sign" $
-      it "parses the number" $
-        property $ \n' -> do
-          let p = signed (hidden C.space) integer
-              n = getNonNegative n'
-              s = '+' : show n
-          prs  p s `shouldParse` n
-          prs' p s `succeedsLeaving` ""
-    context "when number is prefixed with white space" $
-      it "signals correct parse error" $
-        property $ \n -> do
-          let p = signed (hidden C.space) integer
-              s = ' ' : show (n :: Integer)
-          prs  p s `shouldFailWith` err posI
-            (utok ' ' <> etok '+' <> etok '-' <> elabel "integer")
-          prs' p s `failsLeaving` s
-    context "when there is white space between sign and digits" $
-      it "parses it all right" $ do
-        let p = signed (hidden C.space) integer
-            s = "- 123"
-        prs  p s `shouldParse` (-123)
-        prs' p s `succeedsLeaving` ""
+  -- describe "signed" $ do
+  --   context "with integer" $
+  --     it "parses signed integers" $
+  --       property $ \n -> do
+  --         let p = signed (hidden C.space) integer
+  --             s = show n
+  --         prs  p s `shouldParse` n
+  --         prs' p s `succeedsLeaving` ""
+  --   context "with float" $
+  --     it "parses signed floats" $
+  --       property $ \n -> do
+  --         let p = signed (hidden C.space) float
+  --             s = show n
+  --         prs  p s `shouldParse` n
+  --         prs' p s `succeedsLeaving` ""
+  --   context "with number" $
+  --     it "parses singed numbers" $
+  --       property $ \n -> do
+  --         let p = signed (hidden C.space) number
+  --             s = either show show (n :: Either Integer Double)
+  --         prs p s `shouldParse` case n of
+  --           Left  x -> fromIntegral    x
+  --           Right x -> fromFloatDigits x
+  --   context "when number is prefixed with plus sign" $
+  --     it "parses the number" $
+  --       property $ \n' -> do
+  --         let p = signed (hidden C.space) integer
+  --             n = getNonNegative n'
+  --             s = '+' : show n
+  --         prs  p s `shouldParse` n
+  --         prs' p s `succeedsLeaving` ""
+  --   context "when number is prefixed with white space" $
+  --     it "signals correct parse error" $
+  --       property $ \n -> do
+  --         let p = signed (hidden C.space) integer
+  --             s = ' ' : show (n :: Integer)
+  --         prs  p s `shouldFailWith` err posI
+  --           (utok ' ' <> etok '+' <> etok '-' <> elabel "integer")
+  --         prs' p s `failsLeaving` s
+  --   context "when there is white space between sign and digits" $
+  --     it "parses it all right" $ do
+  --       let p = signed (hidden C.space) integer
+  --           s = "- 123"
+  --       prs  p s `shouldParse` (-123)
+  --       prs' p s `succeedsLeaving` ""
 
 ----------------------------------------------------------------------------
 -- Helpers

--- a/tests/Text/Megaparsec/Char/LexerSpec.hs
+++ b/tests/Text/Megaparsec/Char/LexerSpec.hs
@@ -50,13 +50,25 @@ spec = do
           prs  p s `shouldParse` y
           prs' p s `succeedsLeaving` ""
 
-  describe "skipLineComment" $
+  describe "skipLineComment" $ do
     context "when there is no newline at the end of line" $
       it "is picked up successfully" $ do
-        let p = space (void C.spaceChar) (skipLineComment "//") empty <* eof
-            s = "  // this line comment doesn't have a newline at the end "
+        let p = skipLineComment "//"
+            s = "// this line comment doesn't have a newline at the end "
         prs  p s `shouldParse` ()
         prs' p s `succeedsLeaving` ""
+    it "inner characters are labelled properly" $ do
+      let p = skipLineComment "//" <* empty
+          s = "// here we go"
+      prs  p s `shouldFailWith` err (posN (length s) s) (elabel "character")
+      prs' p s `failsLeaving` ""
+
+  describe "skipBlockComment" $
+    it "skips a simple block comment" $ do
+      let p = skipBlockComment "/*" "*/"
+          s = "/* here we go */foo!"
+      prs  p s `shouldParse` ()
+      prs' p s `succeedsLeaving` "foo!"
 
   describe "skipBlockCommentNested" $
     context "when it runs into nested block comments" $
@@ -348,6 +360,14 @@ spec = do
             Left  x -> fromIntegral    (getNonNegative x)
             Right x -> fromFloatDigits (getNonNegative x)
           prs' p s `succeedsLeaving` ""
+    context "when fractional part is interrupted" $
+      it "signals correct parse error" $
+        property $ \(NonNegative n) -> do
+          let p = scientific <* empty :: Parser Scientific
+              s = show (n :: Double)
+          prs p s `shouldFailWith` err (posN (length s) s)
+            (etok 'E' <> etok 'e' <> elabel "digit")
+          prs' p s `failsLeaving` ""
     context "when stream is empty" $
       it "signals correct parse error" $
         prs (scientific :: Parser Scientific) "" `shouldFailWith`

--- a/tests/Text/Megaparsec/Char/LexerSpec.hs
+++ b/tests/Text/Megaparsec/Char/LexerSpec.hs
@@ -14,7 +14,7 @@ import Data.Maybe
 import Data.Monoid ((<>))
 import Data.Scientific (Scientific, fromFloatDigits)
 import Data.Void (Void)
-import Numeric (showInt, showHex, showOct)
+import Numeric (showInt, showHex, showOct, showFFloatAlt)
 import Test.Hspec
 import Test.Hspec.Megaparsec
 import Test.Hspec.Megaparsec.AdHoc
@@ -364,7 +364,7 @@ spec = do
       it "signals correct parse error" $
         property $ \(NonNegative n) -> do
           let p = scientific <* empty :: Parser Scientific
-              s = show (n :: Double)
+              s = showFFloatAlt Nothing (n :: Double) ""
           prs p s `shouldFailWith` err (posN (length s) s)
             (etok 'E' <> etok 'e' <> elabel "digit")
           prs' p s `failsLeaving` ""

--- a/tests/Text/Megaparsec/PermSpec.hs
+++ b/tests/Text/Megaparsec/PermSpec.hs
@@ -10,7 +10,7 @@ import Test.Hspec.Megaparsec
 import Test.Hspec.Megaparsec.AdHoc
 import Test.QuickCheck
 import Text.Megaparsec.Char
-import Text.Megaparsec.Char.Lexer (integer)
+import Text.Megaparsec.Char.Lexer (decimal)
 import Text.Megaparsec.Perm
 
 data CharRows = CharRows
@@ -42,7 +42,7 @@ spec = do
           prs p "" `shouldParse` succ n
     context "when supplied parser fails" $
       it "signals correct parse error" $ do
-          let p = makePermParser (succ <$$> integer)
+          let p = makePermParser (succ <$$> decimal) :: Parser Integer
           prs p "" `shouldFailWith` err posI (ueof <> elabel "integer")
 
   describe "(<$?>)" $ do
@@ -59,7 +59,7 @@ spec = do
     context "when stream in empty" $
       it "returns the default value" $
         property $ \n -> do
-          let p = makePermParser (succ <$?> (n :: Integer, integer))
+          let p = makePermParser (succ <$?> (n :: Integer, decimal))
           prs p "" `shouldParse` succ n
 
   describe "makeExprParser" $


### PR DESCRIPTION
Close #219.

TODO:

- [x] Update the changelog.
- [x] Add the numeric parsers to the benchmarks.
- [x] Fix/adjust the test suite properly.
- [x] Check the Haskell report regarding the precise format of floating point literals, can we parse them without fractional part at all, or is it required?
- [x] In `scientific`, when parsing fractional part (after dot), do only one pass over the result calculating the adjusted coefficient and exponent at the same time. This should make it a little bit faster.
- [x] Refactor the lexer tests to make each test more "focused" on single feature. Also increase the coverage with help of HPC.
