### PR TITLE
Rendering parse error context #205

### DIFF
--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -57,7 +57,7 @@ import Text.Megaparsec.Pos
 import Text.Megaparsec.Stream 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set           as E
-import Debug.Trace
+
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
 #endif

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -252,7 +252,12 @@ parseErrorPretty
 parseErrorPretty e =
   sourcePosStackPretty (errorPos e) <> ":\n" <> parseErrorTextPretty e
 
--- | 
+
+-- | Pretty-print a 'ParseError' and display the line on which the parse error
+-- occurred. The rendered 'String' always ends with a newline.
+--
+-- Assumes that the stream tokens can be coerced to an @Int@ and that the value
+-- integer value @10@ corresponds to a new-line character.
 --
 -- @since 6.0.0
 
@@ -331,8 +336,13 @@ grabLine ts =
       Just (_,v) -> (line, v  )
   where
     -- grab the line content
-    (line, ts') = takeWhile_ f ts
-    f x = fromEnum x /= 10
+    (line, ts') = takeWhile_ isNotNewLine ts
+
+    -- Maybe instead we want to corece to an @Int@, then convert to a @Char@,
+    -- then check if the character is 'LineSeparator' or 'ParagraphSeparator'.
+    -- If this approach is pursued, the change should also occur in
+    -- 'Text.Megaparsec.Stream.defaultAdvance1'.
+    isNotNewLine x = fromEnum x /= 10
 
 -- | Pretty-print a stack of source positions.
 --

--- a/Text/Megaparsec/Pos.hs
+++ b/Text/Megaparsec/Pos.hs
@@ -124,6 +124,7 @@ data SourcePos = SourcePos
   { sourceName   :: FilePath -- ^ Name of source file
   , sourceLine   :: !Pos     -- ^ Line number
   , sourceColumn :: !Pos     -- ^ Column number
+  , totalTokens  :: !Pos
   } deriving (Show, Read, Eq, Ord, Data, Typeable, Generic)
 
 instance NFData SourcePos
@@ -132,14 +133,14 @@ instance NFData SourcePos
 -- file.
 
 initialPos :: FilePath -> SourcePos
-initialPos n = SourcePos n pos1 pos1
+initialPos n = SourcePos n pos1 pos1 pos1
 
 -- | Pretty-print a 'SourcePos'.
 --
 -- @since 5.0.0
 
 sourcePosPretty :: SourcePos -> String
-sourcePosPretty (SourcePos n l c)
+sourcePosPretty (SourcePos n l c _)
   | null n    = showLC
   | otherwise = n <> ":" <> showLC
   where

--- a/Text/Megaparsec/Stream.hs
+++ b/Text/Megaparsec/Stream.hs
@@ -273,13 +273,14 @@ defaultAdvance1 :: Enum t
   -> SourcePos         -- ^ Current position
   -> t                 -- ^ Current token
   -> SourcePos         -- ^ Incremented position
-defaultAdvance1 width (SourcePos n l c) t = npos
+defaultAdvance1 width (SourcePos n l c x) t = npos
   where
     w  = unPos width
     c' = unPos c
+    x' = x <> pos1
     npos =
       case fromEnum t of
-        10 -> SourcePos n (l <> pos1) pos1
-        9  -> SourcePos n l (mkPos $ c' + w - ((c' - 1) `rem` w))
-        _   -> SourcePos n l (c <> pos1)
+        10 -> SourcePos n (l <> pos1) pos1 x'
+        9  -> SourcePos n l (mkPos $ c' + w - ((c' - 1) `rem` w)) x'
+        _  -> SourcePos n l (c <> pos1) x'
 {-# INLINE defaultAdvance1 #-}


### PR DESCRIPTION
An *initial* implementation to render the line of a parse error along with the parse error. Addresses issue #205.

The bar on the side is intended to mimic GHC's 8.2.0's new contextual warning/error rendering.

Let me know your feedback .

Some example renderings:
```
*ghci> let parseTest2 = (\p s -> either (putStr . parseErrorPrettyWithLine s) print $ parse p "example.txt" s) :: Show a => Parsec Void String a -> String -> IO ()
*ghci> parseTest2 (count 10 numberChar) "123456789"
example.txt:1:10:
   |
 1 | 123456789
   |          ^
unexpected end of input
expecting numeric character
*ghci> parseTest2 (count 10 (numberChar <|> Text.Megaparsec.Char.newline)) "12\n3\n45y"
example.txt:3:3:
   |
 3 | 45y
   |   ^
unexpected 'y'
expecting newline or numeric character
*ghci> parseTest2 (count 10 (numberChar <|> Text.Megaparsec.Char.newline)) "12\n3\n45\n"
example.txt:4:1:
   |
 4 | <empty line>
   | ^
unexpected end of input
expecting newline or numeric character
*ghci> putStrLn "Note the contextual line number padding on the left-hand side:"
Note the contextual line number padding on the left-hand side:
*ghci> parseTest2 (count 10010 (numberChar<|>Text.Megaparsec.Char.newline)) $ replicate 10000 '\n' <> "123456789"
example.txt:10001:10:
       |
 10001 | 123456789
       |          ^
unexpected end of input
expecting newline or numeric character
```