### PR TITLE
Use ‘eok’ continuation in tokens when matching empty chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Megaparsec 6.1.1
+
+* Fixed the bug when `tokens` used `cok` continuation even when matching an
+  empty chunk. Now it correctly uses `eok` in this case.
+
 ## Megaparsec 6.1.0
 
 * Improved rendering of offending line in `parseErrorPretty'` in the

--- a/tests/Text/MegaparsecSpec.hs
+++ b/tests/Text/MegaparsecSpec.hs
@@ -1017,6 +1017,13 @@ spec = do
                 z = take (length str) s
             grs  p s (`shouldFailWith` err posI (utoks z <> etoks str))
             grs' p s (`failsLeaving` s)
+      context "when matching the empty string" $
+        it "eok continuation is used" $
+          property $ \str s -> do
+            let p :: MonadParsec Void String m => m String
+                p = (tokens (==) "" <* empty) <|> pure str
+            grs  p s (`shouldParse` str)
+            grs' p s (`succeedsLeaving` s)
 
     describe "takeWhileP" $ do
       context "when stream is not empty" $


### PR DESCRIPTION
Close #245.