### PR TITLE
Make ‘float’ consume only floating point literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 script:
  - cabal configure --enable-tests --enable-coverage -v2 -f dev
  - travis_wait 60 cabal build
- - cabal test --show-details=always --test-option=--qc-max-success=1000
+ - travis_wait 20 cabal test --show-details=always --test-option=--qc-max-success=1000
  - cabal sdist
  - cabal haddock | grep "100%" | wc -l | grep "11"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Megaparsec 6.2.0
+
+* `float` in `Text.Megaparsec.Char.Lexer` and `Text.Megaparsec.Byte.Lexer`
+  now does not accept plain integers. This is the behavior we had in version
+  5 of the library.
+
 ## Megaparsec 6.1.1
 
 * Fixed the bug when `tokens` used `cok` continuation even when matching an

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -60,7 +60,7 @@ library
                     , Text.Megaparsec.Pos
                     , Text.Megaparsec.Stream
   if flag(dev)
-    ghc-options:      -Wall -Werror
+    ghc-options:      -O0 -Wall -Werror
   else
     ghc-options:      -O2 -Wall
   default-language:   Haskell2010
@@ -70,7 +70,7 @@ test-suite tests
   hs-source-dirs:     tests
   type:               exitcode-stdio-1.0
   if flag(dev)
-    ghc-options:      -Wall -Werror
+    ghc-options:      -O0 -Wall -Werror
   else
     ghc-options:      -O2 -Wall
   other-modules:      Control.Applicative.CombinatorsSpec

--- a/tests/Text/Megaparsec/Byte/LexerSpec.hs
+++ b/tests/Text/Megaparsec/Byte/LexerSpec.hs
@@ -138,26 +138,30 @@ spec = do
           let p = float :: Parser Double
               s = B.pack (a : as)
           prs  p s `shouldFailWith`
-            err posI (utok a <> elabel "floating point number")
+            err posI (utok a <> elabel "digit")
           prs' p s `failsLeaving` s
-    context "when stream begins with a decimal number" $
-      it "parses it" $
+    context "when stream begins with an integer (decimal)" $
+      it "signals correct parse error" $
         property $ \n' -> do
           let p = float :: Parser Double
               n = getNonNegative n'
               s = B8.pack $ show (n :: Integer)
-          prs  p s `shouldParse` fromIntegral n
-          prs' p s `succeedsLeaving` ""
+          prs  p s `shouldFailWith` err (posN (B.length s) s)
+            (ueof <> etok 46 <> etok 69 <> etok 101 <> elabel "digit")
+          prs' p s `failsLeaving` ""
     context "when stream is empty" $
       it "signals correct parse error" $
         prs (float :: Parser Double) "" `shouldFailWith`
-          err posI (ueof <> elabel "floating point number")
-    context "when there is float with exponent without explicit sign" $
+          err posI (ueof <> elabel "digit")
+    context "when there is float with just exponent" $
       it "parses it all right" $ do
         let p = float :: Parser Double
-            s = "123e3"
-        prs  p s `shouldParse` 123e3
-        prs' p s `succeedsLeaving` ""
+        prs  p "123e3" `shouldParse` 123e3
+        prs' p "123e3" `succeedsLeaving` ""
+        prs  p "123e+3" `shouldParse` 123e+3
+        prs' p "123e+3" `succeedsLeaving` ""
+        prs  p "123e-3" `shouldParse` 123e-3
+        prs' p "123e-3" `succeedsLeaving` ""
 
   describe "scientific" $ do
     context "when stream begins with a number" $

--- a/tests/Text/Megaparsec/Char/LexerSpec.hs
+++ b/tests/Text/Megaparsec/Char/LexerSpec.hs
@@ -336,26 +336,30 @@ spec = do
           let p = float :: Parser Double
               s = a : as
           prs  p s `shouldFailWith`
-            err posI (utok a <> elabel "floating point number")
+            err posI (utok a <> elabel "digit")
           prs' p s `failsLeaving` s
-    context "when stream begins with a decimal number" $
-      it "parses it" $
+    context "when stream begins with an integer (decimal)" $
+      it "signals correct parse error" $
         property $ \n' -> do
           let p = float :: Parser Double
               n = getNonNegative n'
               s = show (n :: Integer)
-          prs  p s `shouldParse` fromIntegral n
-          prs' p s `succeedsLeaving` ""
+          prs  p s `shouldFailWith` err (posN (length s) s)
+            (ueof <> etok '.' <> etok 'E' <> etok 'e' <> elabel "digit")
+          prs' p s `failsLeaving` ""
     context "when stream is empty" $
       it "signals correct parse error" $
         prs (float :: Parser Double) "" `shouldFailWith`
-          err posI (ueof <> elabel "floating point number")
-    context "when there is float with exponent without explicit sign" $
+          err posI (ueof <> elabel "digit")
+    context "when there is float with just exponent" $
       it "parses it all right" $ do
         let p = float :: Parser Double
-            s = "123e3"
-        prs  p s `shouldParse` 123e3
-        prs' p s `succeedsLeaving` ""
+        prs  p "123e3" `shouldParse` 123e3
+        prs' p "123e3" `succeedsLeaving` ""
+        prs  p "123e+3" `shouldParse` 123e+3
+        prs' p "123e+3" `succeedsLeaving` ""
+        prs  p "123e-3" `shouldParse` 123e-3
+        prs' p "123e-3" `succeedsLeaving` ""
 
   describe "scientific" $ do
     context "when stream begins with a number" $


### PR DESCRIPTION
Close #250.