### PR TITLE
Export token-independent combinators from Text.Megaparsec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Megaparsec 6.4.0
+
+* Exported combinators independent of token type from `Text.Megaparsec`,
+  re-exported `Text.Megaparsec` from `Text.Megaparsec.Char` and
+  `Text.Megaparsec.Byte`.
+
 ## Megaparsec 6.3.0
 
 * Added an `IsString` instance for `ParsecT`. Now it is possible to

--- a/Text/Megaparsec.hs
+++ b/Text/Megaparsec.hs
@@ -101,6 +101,14 @@ module Text.Megaparsec
   , region
   , takeRest
   , atEnd
+  , char
+  , anyChar
+  , notChar
+  , oneOf
+  , noneOf
+  , satisfy
+  , string
+  , string'
     -- * Parser state combinators
   , getInput
   , setInput
@@ -129,6 +137,7 @@ import Control.Monad.State.Class hiding (state)
 import Control.Monad.Trans
 import Control.Monad.Trans.Identity
 import Data.Data (Data)
+import Data.Function (on)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe (fromJust)
 import Data.Proxy
@@ -150,11 +159,14 @@ import qualified Control.Monad.Trans.State.Lazy    as L
 import qualified Control.Monad.Trans.State.Strict  as S
 import qualified Control.Monad.Trans.Writer.Lazy   as L
 import qualified Control.Monad.Trans.Writer.Strict as S
+import qualified Data.CaseInsensitive as CI
 import qualified Data.List.NonEmpty                as NE
 import qualified Data.Set                          as E
 
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
+import Data.Foldable (Foldable (), elem, notElem)
+import Prelude hiding (elem, notElem)
 #endif
 
 -- $reexports
@@ -1408,6 +1420,118 @@ takeRest = takeWhileP Nothing (const True)
 atEnd :: MonadParsec e s m => m Bool
 atEnd = option False (True <$ eof)
 {-# INLINE atEnd #-}
+
+-- | @'char' c@ parses a single character @c@.
+--
+-- > semicolon = char ';'
+
+char :: MonadParsec e s m => Token s -> m (Token s)
+char c = token testChar (Just c)
+  where
+    f x = Tokens (x:|[])
+    testChar x =
+      if x == c
+        then Right x
+        else Left (pure (f x), E.singleton (f c))
+{-# INLINE char #-}
+
+-- | This parser succeeds for any character. Returns the parsed character.
+
+anyChar :: MonadParsec e s m => m (Token s)
+anyChar = satisfy (const True) <?> "character"
+{-# INLINE anyChar #-}
+
+-- | Match any character but the given one. It's a good idea to attach a
+-- 'label' to this parser manually.
+--
+-- @since 6.0.0
+
+notChar :: MonadParsec e s m => Token s -> m (Token s)
+notChar c = satisfy (/= c)
+{-# INLINE notChar #-}
+
+-- | @'oneOf' cs@ succeeds if the current character is in the supplied
+-- collection of characters @cs@. Returns the parsed character. Note that
+-- this parser cannot automatically generate the “expected” component of
+-- error message, so usually you should label it manually with 'label' or
+-- ('<?>').
+--
+-- See also: 'satisfy'.
+--
+-- > digit = oneOf ['0'..'9'] <?> "digit"
+--
+-- __Performance note__: prefer 'satisfy' when you can because it's faster
+-- when you have only a couple of tokens to compare to:
+--
+-- > quoteFast = satisfy (\x -> x == '\'' || x == '\"')
+-- > quoteSlow = oneOf "'\""
+
+oneOf :: (Foldable f, MonadParsec e s m)
+  => f (Token s)
+  -> m (Token s)
+oneOf cs = satisfy (`elem` cs)
+{-# INLINE oneOf #-}
+
+-- | As the dual of 'oneOf', @'noneOf' cs@ succeeds if the current character
+-- /not/ in the supplied list of characters @cs@. Returns the parsed
+-- character. Note that this parser cannot automatically generate the
+-- “expected” component of error message, so usually you should label it
+-- manually with 'label' or ('<?>').
+--
+-- See also: 'satisfy'.
+--
+-- __Performance note__: prefer 'satisfy' and 'notChar' when you can because
+-- it's faster.
+
+noneOf :: (Foldable f, MonadParsec e s m)
+  => f (Token s)
+  -> m (Token s)
+noneOf cs = satisfy (`notElem` cs)
+{-# INLINE noneOf #-}
+
+-- | The parser @'satisfy' f@ succeeds for any character for which the
+-- supplied function @f@ returns 'True'. Returns the character that is
+-- actually parsed.
+--
+-- > digitChar = satisfy isDigit <?> "digit"
+-- > oneOf cs  = satisfy (`elem` cs)
+
+satisfy :: MonadParsec e s m
+  => (Token s -> Bool) -- ^ Predicate to apply
+  -> m (Token s)
+satisfy f = token testChar Nothing
+  where
+    testChar x =
+      if f x
+        then Right x
+        else Left (pure (Tokens (x:|[])), E.empty)
+{-# INLINE satisfy #-}
+
+----------------------------------------------------------------------------
+-- Sequence of characters
+
+-- | @'string' s@ parses a sequence of characters given by @s@. Returns the
+-- parsed string (i.e. @s@).
+--
+-- > divOrMod = string "div" <|> string "mod"
+
+string :: MonadParsec e s m
+  => Tokens s
+  -> m (Tokens s)
+string = tokens (==)
+{-# INLINE string #-}
+
+-- | The same as 'string', but case-insensitive. On success returns string
+-- cased as actually parsed input.
+--
+-- >>> parseTest (string' "foobar") "foObAr"
+-- "foObAr"
+
+string' :: (MonadParsec e s m, CI.FoldCase (Tokens s))
+  => Tokens s
+  -> m (Tokens s)
+string' = tokens ((==) `on` CI.mk)
+{-# INLINE string' #-}
 
 ----------------------------------------------------------------------------
 -- Parser state combinators

--- a/Text/Megaparsec/Byte.hs
+++ b/Text/Megaparsec/Byte.hs
@@ -22,6 +22,7 @@ module Text.Megaparsec.Byte
   , tab
   , space
   , space1
+  , char'
     -- * Categories of characters
   , controlChar
   , spaceChar
@@ -34,17 +35,8 @@ module Text.Megaparsec.Byte
   , octDigitChar
   , hexDigitChar
   , asciiChar
-    -- * More general parsers
-  , C.char
-  , char'
-  , C.anyChar
-  , C.notChar
-  , C.oneOf
-  , C.noneOf
-  , C.satisfy
-    -- * Sequence of bytes
-  , C.string
-  , C.string' )
+    -- * Re-export of the core
+  , module Text.Megaparsec )
 where
 
 import Control.Applicative
@@ -54,7 +46,6 @@ import Data.Maybe (fromMaybe)
 import Data.Proxy
 import Data.Word (Word8)
 import Text.Megaparsec
-import qualified Text.Megaparsec.Char as C
 
 ----------------------------------------------------------------------------
 -- Simple parsers
@@ -62,14 +53,14 @@ import qualified Text.Megaparsec.Char as C
 -- | Parse a newline byte.
 
 newline :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-newline = C.char 10
+newline = char 10
 {-# INLINE newline #-}
 
 -- | Parse a carriage return character followed by a newline character.
 -- Return the sequence of characters parsed.
 
 crlf :: forall e s m. (MonadParsec e s m, Token s ~ Word8) => m (Tokens s)
-crlf = C.string (tokensToChunk (Proxy :: Proxy s) [13,10])
+crlf = string (tokensToChunk (Proxy :: Proxy s) [13,10])
 {-# INLINE crlf #-}
 
 -- | Parse a CRLF (see 'crlf') or LF (see 'newline') end of line. Return the
@@ -84,7 +75,7 @@ eol = (tokenToChunk (Proxy :: Proxy s) <$> newline)
 -- | Parse a tab character.
 
 tab :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-tab = C.char 9
+tab = char 9
 {-# INLINE tab #-}
 
 -- | Skip /zero/ or more white space characters.
@@ -109,51 +100,51 @@ space1 = void $ takeWhile1P (Just "white space") isSpace'
 -- | Parse a control character.
 
 controlChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-controlChar = C.satisfy (isControl . toChar) <?> "control character"
+controlChar = satisfy (isControl . toChar) <?> "control character"
 {-# INLINE controlChar #-}
 
 -- | Parse a space character, and the control characters: tab, newline,
 -- carriage return, form feed, and vertical tab.
 
 spaceChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-spaceChar = C.satisfy isSpace' <?> "white space"
+spaceChar = satisfy isSpace' <?> "white space"
 {-# INLINE spaceChar #-}
 
 -- | Parse an upper-case character.
 
 upperChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-upperChar = C.satisfy (isUpper . toChar) <?> "uppercase letter"
+upperChar = satisfy (isUpper . toChar) <?> "uppercase letter"
 {-# INLINE upperChar #-}
 
 -- | Parse a lower-case alphabetic character.
 
 lowerChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-lowerChar = C.satisfy (isLower . toChar) <?> "lowercase letter"
+lowerChar = satisfy (isLower . toChar) <?> "lowercase letter"
 {-# INLINE lowerChar #-}
 
 -- | Parse an alphabetic character: lower-case or upper-case.
 
 letterChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-letterChar = C.satisfy (isLetter . toChar) <?> "letter"
+letterChar = satisfy (isLetter . toChar) <?> "letter"
 {-# INLINE letterChar #-}
 
 -- | Parse an alphabetic or digit characters.
 
 alphaNumChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-alphaNumChar = C.satisfy (isAlphaNum . toChar) <?> "alphanumeric character"
+alphaNumChar = satisfy (isAlphaNum . toChar) <?> "alphanumeric character"
 {-# INLINE alphaNumChar #-}
 
 -- | Parse a printable character: letter, number, mark, punctuation, symbol
 -- or space.
 
 printChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-printChar = C.satisfy (isPrint . toChar) <?> "printable character"
+printChar = satisfy (isPrint . toChar) <?> "printable character"
 {-# INLINE printChar #-}
 
 -- | Parse an ASCII digit, i.e between “0” and “9”.
 
 digitChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-digitChar = C.satisfy isDigit' <?> "digit"
+digitChar = satisfy isDigit' <?> "digit"
   where
     isDigit' x = x >= 48 && x <= 57
 {-# INLINE digitChar #-}
@@ -161,7 +152,7 @@ digitChar = C.satisfy isDigit' <?> "digit"
 -- | Parse an octal digit, i.e. between “0” and “7”.
 
 octDigitChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-octDigitChar = C.satisfy isOctDigit' <?> "octal digit"
+octDigitChar = satisfy isOctDigit' <?> "octal digit"
   where
     isOctDigit' x = x >= 48 && x <= 55
 {-# INLINE octDigitChar #-}
@@ -170,14 +161,14 @@ octDigitChar = C.satisfy isOctDigit' <?> "octal digit"
 -- “A” and “F”.
 
 hexDigitChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-hexDigitChar = C.satisfy (isHexDigit . toChar) <?> "hexadecimal digit"
+hexDigitChar = satisfy (isHexDigit . toChar) <?> "hexadecimal digit"
 {-# INLINE hexDigitChar #-}
 
 -- | Parse a character from the first 128 characters of the Unicode
 -- character set, corresponding to the ASCII character set.
 
 asciiChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-asciiChar = C.satisfy (< 128) <?> "ASCII character"
+asciiChar = satisfy (< 128) <?> "ASCII character"
 {-# INLINE asciiChar #-}
 
 ----------------------------------------------------------------------------
@@ -195,8 +186,8 @@ asciiChar = C.satisfy (< 128) <?> "ASCII character"
 
 char' :: (MonadParsec e s m, Token s ~ Word8) => Token s -> m (Token s)
 char' c = choice
-  [ C.char c
-  , C.char (fromMaybe c (swapCase c)) ]
+  [ char c
+  , char (fromMaybe c (swapCase c)) ]
   where
     swapCase x
       | isUpper g = fromChar (toLower g)

--- a/Text/Megaparsec/Char.hs
+++ b/Text/Megaparsec/Char.hs
@@ -25,6 +25,7 @@ module Text.Megaparsec.Char
   , tab
   , space
   , space1
+  , char'
     -- * Categories of characters
   , controlChar
   , spaceChar
@@ -45,33 +46,15 @@ module Text.Megaparsec.Char
   , latin1Char
   , charCategory
   , categoryName
-    -- * More general parsers
-  , char
-  , char'
-  , anyChar
-  , notChar
-  , oneOf
-  , noneOf
-  , satisfy
-    -- * Sequence of characters
-  , string
-  , string' )
+    -- * Re-export of the core
+  , module Text.Megaparsec )
 where
 
 import Control.Applicative
 import Data.Char
-import Data.Function (on)
 import Data.Functor (void)
-import Data.List.NonEmpty (NonEmpty (..))
 import Data.Proxy
 import Text.Megaparsec
-import qualified Data.CaseInsensitive as CI
-import qualified Data.Set             as E
-
-#if !MIN_VERSION_base(4,8,0)
-import Data.Foldable (Foldable (), elem, notElem)
-import Prelude hiding (elem, notElem)
-#endif
 
 ----------------------------------------------------------------------------
 -- Simple parsers
@@ -121,6 +104,25 @@ space = void $ takeWhileP (Just "white space") isSpace
 space1 :: (MonadParsec e s m, Token s ~ Char) => m ()
 space1 = void $ takeWhile1P (Just "white space") isSpace
 {-# INLINE space1 #-}
+
+-- | The same as 'char' but case-insensitive. This parser returns the
+-- actually parsed character preserving its case.
+--
+-- >>> parseTest (char' 'e') "E"
+-- 'E'
+-- >>> parseTest (char' 'e') "G"
+-- 1:1:
+-- unexpected 'G'
+-- expecting 'E' or 'e'
+
+char' :: (MonadParsec e s m, Token s ~ Char) => Token s -> m (Token s)
+char' c = choice [char c, char (swapCase c)]
+  where
+    swapCase x
+      | isUpper x = toLower x
+      | isLower x = toUpper x
+      | otherwise = x
+{-# INLINE char' #-}
 
 ----------------------------------------------------------------------------
 -- Categories of characters
@@ -287,137 +289,3 @@ categoryName = \case
   Surrogate            -> "surrogate character"
   PrivateUse           -> "private-use Unicode character"
   NotAssigned          -> "non-assigned Unicode character"
-
-----------------------------------------------------------------------------
--- More general parsers
-
--- | @'char' c@ parses a single character @c@.
---
--- > semicolon = char ';'
-
-char :: MonadParsec e s m => Token s -> m (Token s)
-char c = token testChar (Just c)
-  where
-    f x = Tokens (x:|[])
-    testChar x =
-      if x == c
-        then Right x
-        else Left (pure (f x), E.singleton (f c))
-{-# INLINE char #-}
-
--- | The same as 'char' but case-insensitive. This parser returns the
--- actually parsed character preserving its case.
---
--- >>> parseTest (char' 'e') "E"
--- 'E'
--- >>> parseTest (char' 'e') "G"
--- 1:1:
--- unexpected 'G'
--- expecting 'E' or 'e'
-
-char' :: (MonadParsec e s m, Token s ~ Char) => Token s -> m (Token s)
-char' c = choice [char c, char (swapCase c)]
-  where
-    swapCase x
-      | isUpper x = toLower x
-      | isLower x = toUpper x
-      | otherwise = x
-{-# INLINE char' #-}
-
--- | This parser succeeds for any character. Returns the parsed character.
-
-anyChar :: MonadParsec e s m => m (Token s)
-anyChar = satisfy (const True) <?> "character"
-{-# INLINE anyChar #-}
-
--- | Match any character but the given one. It's a good idea to attach a
--- 'label' to this parser manually.
---
--- @since 6.0.0
-
-notChar :: MonadParsec e s m => Token s -> m (Token s)
-notChar c = satisfy (/= c)
-{-# INLINE notChar #-}
-
--- | @'oneOf' cs@ succeeds if the current character is in the supplied
--- collection of characters @cs@. Returns the parsed character. Note that
--- this parser cannot automatically generate the “expected” component of
--- error message, so usually you should label it manually with 'label' or
--- ('<?>').
---
--- See also: 'satisfy'.
---
--- > digit = oneOf ['0'..'9'] <?> "digit"
---
--- __Performance note__: prefer 'satisfy' when you can because it's faster
--- when you have only a couple of tokens to compare to:
---
--- > quoteFast = satisfy (\x -> x == '\'' || x == '\"')
--- > quoteSlow = oneOf "'\""
-
-oneOf :: (Foldable f, MonadParsec e s m)
-  => f (Token s)
-  -> m (Token s)
-oneOf cs = satisfy (`elem` cs)
-{-# INLINE oneOf #-}
-
--- | As the dual of 'oneOf', @'noneOf' cs@ succeeds if the current character
--- /not/ in the supplied list of characters @cs@. Returns the parsed
--- character. Note that this parser cannot automatically generate the
--- “expected” component of error message, so usually you should label it
--- manually with 'label' or ('<?>').
---
--- See also: 'satisfy'.
---
--- __Performance note__: prefer 'satisfy' and 'notChar' when you can because
--- it's faster.
-
-noneOf :: (Foldable f, MonadParsec e s m)
-  => f (Token s)
-  -> m (Token s)
-noneOf cs = satisfy (`notElem` cs)
-{-# INLINE noneOf #-}
-
--- | The parser @'satisfy' f@ succeeds for any character for which the
--- supplied function @f@ returns 'True'. Returns the character that is
--- actually parsed.
---
--- > digitChar = satisfy isDigit <?> "digit"
--- > oneOf cs  = satisfy (`elem` cs)
-
-satisfy :: MonadParsec e s m
-  => (Token s -> Bool) -- ^ Predicate to apply
-  -> m (Token s)
-satisfy f = token testChar Nothing
-  where
-    testChar x =
-      if f x
-        then Right x
-        else Left (pure (Tokens (x:|[])), E.empty)
-{-# INLINE satisfy #-}
-
-----------------------------------------------------------------------------
--- Sequence of characters
-
--- | @'string' s@ parses a sequence of characters given by @s@. Returns the
--- parsed string (i.e. @s@).
---
--- > divOrMod = string "div" <|> string "mod"
-
-string :: MonadParsec e s m
-  => Tokens s
-  -> m (Tokens s)
-string = tokens (==)
-{-# INLINE string #-}
-
--- | The same as 'string', but case-insensitive. On success returns string
--- cased as actually parsed input.
---
--- >>> parseTest (string' "foobar") "foObAr"
--- "foObAr"
-
-string' :: (MonadParsec e s m, CI.FoldCase (Tokens s))
-  => Tokens s
-  -> m (Tokens s)
-string' = tokens ((==) `on` CI.mk)
-{-# INLINE string' #-}

--- a/tests/Text/Megaparsec/PermSpec.hs
+++ b/tests/Text/Megaparsec/PermSpec.hs
@@ -15,7 +15,7 @@ import Text.Megaparsec.Perm
 
 data CharRows = CharRows
   { getChars :: (Char, Char, Char)
-  , getInput :: String }
+  , getRInput :: String }
   deriving (Eq, Show)
 
 instance Arbitrary CharRows where
@@ -74,7 +74,7 @@ spec = do
             preb = take (bis !! 1) s
             cis  = elemIndices c s
             prec = take (cis !! 1) s
-            s    = getInput v
+            s    = getRInput v
         if | length bis > 1 && (length cis <= 1 || head bis < head cis) ->
                prs_ p s `shouldFailWith` err (posN (bis !! 1) s)
                  ( utok b <> eeof <>


### PR DESCRIPTION
There's one inconsistency and one inconvenience when it comes to the module structure of megaparsec.

* The inconsistency is that some combinators are exported from `Text.Megaparsec` (i.e. `match`, `takeRest`), while some are exported from `Text.Megaparsec.Char` (i.e. `satisfy`), although there is nothing Char-specific in `satisfy`.

* The inconvenience is that almost always there are two imports required to use `megaparsec`: I need to import both `Text.Megaparsec` for core definitions and `Text.Megaparsec.Char` for Char-specific definitions.

I figured out a simple way to address both concerns at once, and have a principled way to structure the modules. The principle is this:

* all combinators that do not assume a specific token type go into `Text.Megaparsec`
* combinators that assume a specific token type (i.e. `Token s ~ Char`) go into a corresponding module

Because of this, I moved `char`, `oneOf`, `noneOf`, `satisfy`, etc, to `Text.Megaparsec`. This eliminated the awkward fact that `Text.Megaparsec.Byte` was dependent on `Text.Megaparsec.Char`, while those modules are actually for completely different input streams and, in principle, are independent.

Finally, I re-exported `Text.Megaparsec` from `Text.Megaparsec.Char` and `Text.Megaparsec.Byte`, because this way only one import is needed. I cannot imagine a case where a user would want to use `Text.Megaparsec.Char` without core definitions from `Text.Megaparsec`.

The breakage is minimal (there might be a few name conflicts, because `Text.Megaparsec` exports more combinators now), but this should not be a problem.

This makes the module structure more principled and ergonomic.