### PR TITLE
Fast scan primitive, like attoparsec's

### DIFF
--- a/tests/Text/Megaparsec/StreamSpec.hs
+++ b/tests/Text/Megaparsec/StreamSpec.hs
@@ -90,6 +90,9 @@ spec = do
       it "extracts a chunk that is a prefix consisting of matching tokens" $
         property $ \s ->
           takeWhile_ isLetter s === span isLetter s
+    describe "scan_" $
+      it "extracts a chunk that is a prefix consisting of filtered tokens" $
+        scan_ (\st c -> if (st /= '\\' && c == '!') then Nothing else Just c) '\0' ("aaaa\\!aaaa!" :: String) === ("aaaa\\!aaaa", "!")
 
   describe "ByteString instance of Stream" $ do
     describe "tokenToChunk" $
@@ -165,6 +168,9 @@ spec = do
         property $ \s ->
           let f = isLetter . chr . fromIntegral
           in takeWhile_ f s === B.span f s
+    describe "scan_" $
+      it "extracts a chunk that is a prefix consisting of filtered tokens" $
+        scan_ (\st c -> if (st /= 0x5c && c == 0x21) then Nothing else Just c) 0 ("aaaa\\!aaaa!" :: B.ByteString) === ("aaaa\\!aaaa", "!")
 
   describe "Lazy ByteString instance of Stream" $ do
     describe "tokenToChunk" $
@@ -240,6 +246,9 @@ spec = do
         property $ \s ->
           let f = isLetter . chr . fromIntegral
           in takeWhile_ f s === BL.span f s
+    describe "scan_" $
+      it "extracts a chunk that is a prefix consisting of filtered tokens" $
+        scan_ (\st c -> if (st /= 0x5c && c == 0x21) then Nothing else Just c) 0 ("aaaa\\!aaaa!" :: BL.ByteString) === ("aaaa\\!aaaa", "!")
 
   describe "Text instance of Stream" $ do
     describe "tokenToChunk" $
@@ -314,6 +323,9 @@ spec = do
       it "extracts a chunk that is a prefix consisting of matching tokens" $
         property $ \s ->
           takeWhile_ isLetter s === T.span isLetter s
+    describe "scan_" $
+      it "extracts a chunk that is a prefix consisting of filtered tokens" $
+        scan_ (\st c -> if (st /= '\\' && c == '!') then Nothing else Just c) '\0' ("aaaa\\!aaaa!" :: T.Text) === ("aaaa\\!aaaa", "!")
 
   describe "Lazy Text instance of Stream" $ do
     describe "tokenToChunk" $
@@ -388,6 +400,9 @@ spec = do
       it "extracts a chunk that is a prefix consisting of matching tokens" $
         property $ \s ->
           takeWhile_ isLetter s === TL.span isLetter s
+    describe "scan_" $
+      it "extracts a chunk that is a prefix consisting of filtered tokens" $
+        scan_ (\st c -> if (st /= '\\' && c == '!') then Nothing else Just c) '\0' ("aaaa\\!aaaa!" :: TL.Text) === ("aaaa\\!aaaa", "!")
 
 ----------------------------------------------------------------------------
 -- Helpers


### PR DESCRIPTION
Attoparsec has the `scan :: s -> (s -> Word8 -> Maybe s) -> Parser ByteString` function to efficiently do a stateful scan through the input text. I implemented an equivalent `scanP` parser for Megaparsec, and also brought in some dirty tricks to help it be faster than just writing the parser in a more contorted way. 

[megaparsec-scan-bench](https://github.com/typedrat/megaparsec-scan-bench) is the benchmark I made to show how much of a benefit it provides. It's a standard criterion benchmark, build and run the executable to generate your own report or you can look at the results from my desktop [here](https://gist.github.com/typedrat/3b17f63715a5b6105c05fbb8522d9119).

The executive summary is that it's effectively even with string when written in terms of the existing interface, but has consistent 2x to _10x_ speedups for both lazy and strict Text and ByteStrings, even beating attoparsec in some cases.

I have done enough that it's suiting my needs, but I'd be happy to develop it further/improve it if that means getting it upstream.