### PR TITLE
Fix `charLiteral` for long character escape sequences

### DIFF
--- a/Text/Megaparsec/Char/Lexer.hs
+++ b/Text/Megaparsec/Char/Lexer.hs
@@ -397,7 +397,7 @@ charLiteral :: (MonadParsec e s m, Token s ~ Char) => m Char
 charLiteral = label "literal character" $ do
   -- The @~@ is needed to avoid requiring a MonadFail constraint,
   -- and we do know that r will be non-empty if count' succeeds.
-  r <- lookAhead (count' 1 8 anySingle)
+  r <- lookAhead (count' 1 10 anySingle)
   case listToMaybe (Char.readLitChar r) of
     Just (c, r') -> c <$ skipCount (length r - length r') anySingle
     Nothing      -> unexpected (Tokens (head r:|[]))


### PR DESCRIPTION
I could trigger it with the following: `char '"' *> manyTill L.charLiteral (char '"')` and the imput `"\154972\&1"`