### PR TITLE
Improve case-insensitive char matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@
 * Added `mapParseError` and `withParsecT` to allow changing the type of
   the custom data component in parse errors.
 
+* Improved case-insensitive character matching in the cases when e.g.
+  `isLower` and `isUpper` both return `False`. Functions affected:
+  `Text.Megaparsec.Char.char'`.
+
 * Dropped support for GHC 7.8.
 
 ## Megaparsec 6.5.0

--- a/Text/Megaparsec/Byte.hs
+++ b/Text/Megaparsec/Byte.hs
@@ -44,9 +44,8 @@ module Text.Megaparsec.Byte
 where
 
 import Control.Applicative
-import Data.Char
+import Data.Char hiding (toLower, toUpper)
 import Data.Functor (void)
-import Data.Maybe (fromMaybe)
 import Data.Proxy
 import Data.Word (Word8)
 import Text.Megaparsec
@@ -209,15 +208,9 @@ char = single
 
 char' :: (MonadParsec e s m, Token s ~ Word8) => Token s -> m (Token s)
 char' c = choice
-  [ char c
-  , char (fromMaybe c (swapCase c)) ]
-  where
-    swapCase x
-      | isUpper g = fromChar (toLower g)
-      | isLower g = fromChar (toUpper g)
-      | otherwise = Nothing
-      where
-        g = toChar x
+  [ char (toLower c)
+  , char (toUpper c)
+  ]
 {-# INLINE char' #-}
 
 ----------------------------------------------------------------------------
@@ -239,11 +232,23 @@ toChar :: Word8 -> Char
 toChar = chr . fromIntegral
 {-# INLINE toChar #-}
 
--- | Convert a char to byte.
+-- | Convert a byte to its upper-case version.
 
-fromChar :: Char -> Maybe Word8
-fromChar x = let p = ord x in
-  if p > 0xff
-    then Nothing
-    else Just (fromIntegral p)
-{-# INLINE fromChar #-}
+toUpper :: Word8 -> Word8
+toUpper x
+  | x >= 97 && x <= 122 = x - 32
+  | x == 247 = x -- division sign
+  | x == 255 = x -- latin small letter y with diaeresis
+  | x >= 224 = x - 32
+  | otherwise = x
+{-# INLINE toUpper #-}
+
+-- | Convert a byte to its lower-case version.
+
+toLower :: Word8 -> Word8
+toLower x
+  | x >= 65 && x <= 90 = x + 32
+  | x == 215 = x -- multiplication sign
+  | x >= 192 && x <= 222 = x + 32
+  | otherwise = x
+{-# INLINE toLower #-}

--- a/Text/Megaparsec/Char.hs
+++ b/Text/Megaparsec/Char.hs
@@ -308,10 +308,9 @@ char = single
 -- expecting 'E' or 'e'
 
 char' :: (MonadParsec e s m, Token s ~ Char) => Token s -> m (Token s)
-char' c = choice [char c, char (swapCase c)]
-  where
-    swapCase x
-      | isUpper x = toLower x
-      | isLower x = toUpper x
-      | otherwise = x
+char' c = choice
+  [ char (toLower c)
+  , char (toUpper c)
+  , char (toTitle c)
+  ]
 {-# INLINE char' #-}

--- a/tests/Text/Megaparsec/ByteSpec.hs
+++ b/tests/Text/Megaparsec/ByteSpec.hs
@@ -123,13 +123,16 @@ spec = do
         property $ \ch s -> do
           let sl = B.cons (liftChar toLower ch) s
               su = B.cons (liftChar toUpper ch) s
+              st = B.cons (liftChar toTitle ch) s
           prs  (char' ch) sl `shouldParse`     liftChar toLower ch
           prs  (char' ch) su `shouldParse`     liftChar toUpper ch
+          prs  (char' ch) st `shouldParse`     liftChar toTitle ch
           prs' (char' ch) sl `succeedsLeaving` s
           prs' (char' ch) su `succeedsLeaving` s
+          prs' (char' ch) st `succeedsLeaving` s
     context "when stream does not begin with the character specified as argument" $
       it "signals correct parse error" $
-        property $ \ch ch' s -> liftChar toLower ch /= liftChar toLower ch' ==> do
+        property $ \ch ch' s -> not (casei ch ch') ==> do
           let s' = B.cons ch' s
               ms = utok ch' <> etok (liftChar toLower ch) <> etok (liftChar toUpper ch)
           prs  (char' ch) s' `shouldFailWith` err posI ms
@@ -241,3 +244,11 @@ fromChar x = let p = ord x in
 
 liftChar :: (Char -> Char) -> Word8 -> Word8
 liftChar f x = (fromMaybe x . fromChar . f . toChar) x
+
+-- | Compare two characters case-insensitively.
+
+casei :: Word8 -> Word8 -> Bool
+casei x y =
+  x == liftChar toLower y ||
+  x == liftChar toUpper y ||
+  x == liftChar toTitle y


### PR DESCRIPTION
Close #307.

Improved case-insensitive character matching in the cases when e.g. `isLower` and `isUpper` both return `False`. Functions affected: `Text.Megaparsec.Char.char'`.

Also re-implemented `Text.Megaparsec.Byte.char'` without semantic changes.