### PR TITLE
UndecidableInstances needed in one module for GHC 8.6.

### DIFF
--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -26,6 +26,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE UndecidableInstances#-}
 
 module Text.Megaparsec.Error
   ( -- * Parse error type


### PR DESCRIPTION
See https://ghc.haskell.org/trac/ghc/wiki/Migration/8.6#UndecidableInstancesispickier.

With this change, I am able to build on GHC 8.6.1-beta1.  Without it, the four uses of `Token s` in instance heads give errors.