### PR TITLE
Do not alter labels artificially

### DIFF
--- a/Text/Megaparsec/Internal.hs
+++ b/Text/Megaparsec/Internal.hs
@@ -344,8 +344,10 @@ pFancyFailure xs = ParsecT $ \s@(State _ o _) _ _ _ eerr ->
 pLabel :: String -> ParsecT e s m a -> ParsecT e s m a
 pLabel l p = ParsecT $ \s cok cerr eok eerr ->
   let el = Label <$> NE.nonEmpty l
-      cl = Label . (NE.fromList "the rest of " <>) <$> NE.nonEmpty l
-      cok' x s' hs = cok x s' (refreshLastHint hs cl)
+      cok' x s' hs =
+        case el of
+          Nothing -> cok x s' (refreshLastHint hs Nothing)
+          Just  _ -> cok x s' hs
       eok' x s' hs = eok x s' (refreshLastHint hs el)
       eerr'    err = eerr $
         case err of

--- a/tests/Text/MegaparsecSpec.hs
+++ b/tests/Text/MegaparsecSpec.hs
@@ -441,12 +441,12 @@ spec = do
               grs  p s (`shouldFailWith` err 1 mempty)
               grs' p s (`failsLeaving` "")
         context "inner parser produces hints" $
-          it "replaces the last hint with “the rest of <label>”" $
+          it "does not alter the hints" $
             property $ \lbl a -> not (null lbl) ==> do
               let p :: MonadParsec Void String m => m String
                   p = label lbl (many (char a)) <* empty
                   s = [a]
-              grs  p s (`shouldFailWith` err 1 (elabel $ "the rest of " ++ lbl))
+              grs  p s (`shouldFailWith` err 1 (etok a))
               grs' p s (`failsLeaving` "")
       context "when inner parser consumes and fails" $
         it "reports parse error without modification" $


### PR DESCRIPTION
Close #316.

In particular, don't prepend the phrase “the rest of ”.