### PR TITLE
Fix a bug in ‘errorBundlePretty’

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Megaparsec 7.0.1
+
+* Fixed a bug in `errorBundlePretty`. Previously the question sign `?` was
+  erroneously inserted before offending line in 2nd and later parse errors.
+
 ## Megaparsec 7.0.0
 
 ### General

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -343,24 +343,24 @@ errorBundlePretty ParseErrorBundle {..} =
     f (o, !pst) e = (o . (outChunk ++), pst')
       where
         (epos, sline, pst') = reachOffset (errorOffset e) pst
-        ppos = pstateSourcePos pst
         outChunk =
           "\n" <> sourcePosPretty epos <> ":\n" <>
           padding <> "|\n" <>
-          lineNumber <> " | " <> gpadding <> sline <> "\n" <>
+          lineNumber <> " | " <> sline <> "\n" <>
           padding <> "| " <> rpadding <> pointer <> "\n" <>
           parseErrorTextPretty e
         lineNumber = (show . unPos . sourceLine) epos
         padding = replicate (length lineNumber + 1) ' '
-        gpadding = replicate gpshift '?'
-        gpshift = unPos (sourceColumn ppos) - 1
-        rpadding = replicate rpshift ' '
+        rpadding =
+          if pointerLen > 0
+            then replicate rpshift ' '
+            else ""
         rpshift = unPos (sourceColumn epos) - 1
-        pointer = replicate
-          (if rpshift + elen > gpshift + slineLen
-             then gpshift + slineLen - rpshift + 1
-             else elen)
-          '^'
+        pointer = replicate pointerLen '^'
+        pointerLen =
+          if rpshift + elen > slineLen
+            then slineLen - rpshift + 1
+            else elen
         slineLen = length sline
         elen =
           case e of

--- a/tests/Text/Megaparsec/ErrorSpec.hs
+++ b/tests/Text/Megaparsec/ErrorSpec.hs
@@ -151,7 +151,7 @@ spec = do
                   }
                 }
           errorBundlePretty bundle `shouldBe`
-            "1:6:\n  |\n1 | ????foo\n  |      ^\nunexpected 'o'\nexpecting 'x'\n"
+            "1:6:\n  |\n1 | foo\n  | \nunexpected 'o'\nexpecting 'x'\n"
       context "and greater than parse error column" $
         it "is rendered correctly" $ do
           let s = "foo" :: String
@@ -167,7 +167,7 @@ spec = do
                   }
                 }
           errorBundlePretty bundle `shouldBe`
-            "1:10:\n  |\n1 | ?????????foo\n  |          ^\nunexpected 'o'\nexpecting 'x'\n"
+            "1:10:\n  |\n1 | foo\n  | \nunexpected 'o'\nexpecting 'x'\n"
     it "takes tab width into account correctly" $
       property $ \w' -> do
         let s  = "\tsomething\t" :: String
@@ -190,7 +190,7 @@ spec = do
            "\n  | " ++ tabRep ++ "^\nunexpected 's'\nexpecting 'x'\n")
     it "displays multi-error bundle correctly" $ do
       let s = "something\ngood\n" :: String
-          pe0 = err 0 (utok 's' <> etok 'x') :: PE
+          pe0 = err 2 (utok 'm' <> etok 'x') :: PE
           pe1 = err 10 (utok 'g' <> etok 'y') :: PE
           bundle = ParseErrorBundle
             { bundleErrors = pe0 :| [pe1]
@@ -203,7 +203,7 @@ spec = do
               }
             }
       errorBundlePretty bundle `shouldBe`
-        "1:1:\n  |\n1 | something\n  | ^\nunexpected 's'\nexpecting 'x'\n\n2:1:\n  |\n2 | good\n  | ^\nunexpected 'g'\nexpecting 'y'\n"
+        "1:3:\n  |\n1 | something\n  |   ^\nunexpected 'm'\nexpecting 'x'\n\n2:1:\n  |\n2 | good\n  | ^\nunexpected 'g'\nexpecting 'y'\n"
 
   describe "parseErrorPretty" $ do
     it "shows unknown ParseError correctly" $


### PR DESCRIPTION
Previously the question sign `?` was erroneously inserted before offending line in 2nd and later parse errors.