### PR TITLE
Add decimalGroup lexer to allow underscores

### DIFF
--- a/bench/memory/Main.hs
+++ b/bench/memory/Main.hs
@@ -47,6 +47,7 @@ main = mainWith $ do
   bparser "takeWhileP" manyAs (const $ takeWhileP Nothing (== 'a'))
   bparser "takeWhile1P" manyAs (const $ takeWhile1P Nothing (== 'a'))
   bparser "decimal" mkInt (const (L.decimal :: Parser Integer))
+  bparser "groupedDecimal" mkInt (const (L.groupedDecimal :: Parser Integer))
   bparser "octal" mkInt (const (L.octal :: Parser Integer))
   bparser "hexadecimal" mkInt (const (L.hexadecimal :: Parser Integer))
   bparser "scientific" mkInt (const L.scientific)

--- a/bench/speed/Main.hs
+++ b/bench/speed/Main.hs
@@ -45,6 +45,7 @@ main = defaultMain
   , bparser "takeWhileP" manyAs (const $ takeWhileP Nothing (== 'a'))
   , bparser "takeWhile1P" manyAs (const $ takeWhile1P Nothing (== 'a'))
   , bparser "decimal" mkInt (const (L.decimal :: Parser Integer))
+  , bparser "groupedDecimal" mkInt (const (L.groupedDecimal :: Parser Integer))
   , bparser "octal" mkInt (const (L.octal :: Parser Integer))
   , bparser "hexadecimal" mkInt (const (L.hexadecimal :: Parser Integer))
   , bparser "scientific" mkInt (const L.scientific)

--- a/tests/Text/Megaparsec/Char/LexerSpec.hs
+++ b/tests/Text/Megaparsec/Char/LexerSpec.hs
@@ -293,6 +293,65 @@ spec = do
         prs (decimal :: Parser Integer) "" `shouldFailWith`
           err 0 (ueof <> elabel "integer")
 
+  describe "groupedDecimal" $ do
+    context "when stream begins with decimal digits" $
+      it "they are parsed as an integer" $
+        property $ \n' -> do
+          let p = groupedDecimal :: Parser Integer
+              n = getNonNegative n'
+              s = showInt n ""
+          prs  p s `shouldParse` n
+          prs' p s `succeedsLeaving` ""
+    context "when stream contains an underscore" $
+      it "they are parsed as an integer" $
+        property $ \n1' n2' -> do
+          let p = groupedDecimal :: Parser Integer
+              n1 = getNonNegative n1' :: Integer
+              n2 = getNonNegative n2' :: Integer
+              s = (showInt n1 "") ++ "_" ++ (showInt n2 "")
+          prs  p s `shouldParse` (read $ (showInt n1 "") ++ (showInt n2 ""))
+          prs' p s `succeedsLeaving` ""
+    context "when stream contains double underscores" $
+      it "they are parsed as an integer" $
+        property $ \n1' n2' -> do
+          let p = groupedDecimal :: Parser Integer
+              n1 = getNonNegative n1' :: Integer
+              n2 = getNonNegative n2' :: Integer
+              s = (showInt n1 "") ++ "__" ++ (showInt n2 "")
+          prs  p s `shouldParse` (read $ (showInt n1 "") ++ (showInt n2 ""))
+          prs' p s `succeedsLeaving` ""
+    context "when stream starts with an underscore" $
+      it "signals correct parse error" $
+        property $ \n' -> do
+          let p = groupedDecimal :: Parser Integer
+              n = getNonNegative n' :: Integer
+              s = '_' : showInt n ""
+          prs  p s `shouldFailWith` err 0 (utok '_' <> elabel "integer")
+    context "when stream ends with an underscore" $
+      it "signals correct parse error" $
+        property $ \n' -> do
+          let p = groupedDecimal :: Parser Integer
+              n = getNonNegative n' :: Integer
+              s = showInt n "" ++ "_"
+          prs  p s `shouldFailWith` err (length s - 1) (utok '_' <> elabel "integer")
+    context "when stream starts with an underscore" $
+      it "signals correct parse error" $
+        property $ \n' -> do
+          let p = groupedDecimal :: Parser Integer
+              n = getNonNegative n' :: Integer
+              s = '_' : showInt n ""
+          prs  p s `shouldFailWith` err 0 (utok '_' <> elabel "integer")
+    context "when stream does not begin with decimal digits" $
+      it "signals correct parse error" $
+        property $ \a as -> not (isDigit a || a == '_') ==> do
+          let p = groupedDecimal :: Parser Integer
+              s = a : as
+          prs  p s `shouldFailWith` err 0 (utok a <> elabel "integer")
+    context "when stream is empty" $
+      it "signals correct parse error" $
+        prs (groupedDecimal :: Parser Integer) "" `shouldFailWith`
+          err 0 (ueof <> elabel "integer")
+
   describe "binary" $ do
     context "when stream begins with binary digits" $
       it "they are parsed as an integer" $


### PR DESCRIPTION
This PR adds a new `digits'` function to allow the parsing of integers with underscores in them.

Some examples of where this style of number is used:
- New GHC `>8.6.1` (See https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0009-numeric-underscores.rst#validity-examples)
- Languages such as Ruby
- TOML (See tomland which uses megaparsec https://github.com/kowainik/tomland/pull/97)

This only does integers so far, and I'll need some help making this performant but I'm opening the PR now to see if there's any appetite for it.