### PR TITLE
Fixes test failure for characters that have different upper and title cases.

### DIFF
--- a/tests/Text/Megaparsec/CharSpec.hs
+++ b/tests/Text/Megaparsec/CharSpec.hs
@@ -5,7 +5,7 @@ module Text.Megaparsec.CharSpec (spec) where
 
 import Control.Monad
 import Data.Char
-import Data.List (partition, isPrefixOf)
+import Data.List (nub, partition, isPrefixOf)
 import Data.Monoid ((<>))
 import Test.Hspec
 import Test.Hspec.Megaparsec
@@ -201,6 +201,9 @@ spec = do
           prs  (char ch) "" `shouldFailWith` err 0 (ueof <> etok ch)
 
   describe "char'" $ do
+    -- a character with different lower, upper and title cases ('ǳ',
+    -- 'ǲ' and 'Ǳ' respectively)
+    let distinctTitleCase = 'ǳ'
     context "when stream begins with the character specified as argument" $ do
       it "parses the character" $
         property $ \ch s -> do
@@ -220,6 +223,12 @@ spec = do
                 s' = '\9412' : s
             prs (char' ch) s' `shouldParse` '\9412'
             prs' (char' ch) s' `succeedsLeaving` s
+      context "when character has different lower, upper and title cases" $
+        it "parses the character in lower, upper or title case" $ do
+          let p = prs (char' distinctTitleCase)
+          p [distinctTitleCase] `shouldParse` distinctTitleCase
+          p [toUpper distinctTitleCase] `shouldParse` toUpper distinctTitleCase
+          p [toTitle distinctTitleCase] `shouldParse` toTitle distinctTitleCase
     context "when stream does not begin with the character specified as argument" $ do
       it "signals correct parse error" $
         property $ \ch ch' s -> not (casei ch ch') ==> do
@@ -233,11 +242,19 @@ spec = do
             let ms = utok ch <> etok '\9438' <> etok '\9412'
                 s' = ch : s
             prs (char' '\9438') s' `shouldFailWith` err 0 ms
-    context "when stream is empty" $
+    context "when stream is empty" $ do
       it "signals correct parse error" $
         property $ \ch -> do
-          let ms = ueof <> etok (toLower ch) <> etok (toUpper ch)
+          let options = etok <$> [toLower ch, toTitle ch, toUpper ch]
+              ms = ueof <> mconcat (nub options)
           prs  (char' ch) "" `shouldFailWith` err 0 ms
+      context "when character has different lower, upper and title cases" $
+        it "signals correct parse error" $ do
+          let ms = mconcat [ ueof
+                           , etok distinctTitleCase
+                           , etok $ toUpper distinctTitleCase
+                           , etok $ toTitle distinctTitleCase ]
+          prs (char' distinctTitleCase) "" `shouldFailWith` err 0 ms
 
   describe "string" $ do
     context "when stream is prefixed with given string" $


### PR DESCRIPTION
Certain Unicode characters like `ǳ` have different title and upper cases ('ǲ' and 'Ǳ' respectively). This caused the test property for `char'` to fail occasionally:

```
Failures:

  tests/Text/Megaparsec/CharSpec.hs:240:11:
  1) char', when stream is empty, signals correct parse error
       Falsifiable (after 211 tests and 1 shrink):
         '\499'
       the parser is expected to fail with:
         1:1:
           |
         1 | <empty line>
           | ^
         unexpected end of input
         expecting 'Ǳ' or 'ǳ'
       but it failed with:
         1:1:
           |
         1 | <empty line>
           | ^
         unexpected end of input
         expecting 'Ǳ', 'ǲ', or 'ǳ'

  To rerun use: --match "/char'/when stream is empty/signals correct parse error/"

Randomized with seed 1385291659
```

This PR fixes this test property and adds a couple of regression tests for `ǳ` specifically to consistently catch problems like this in the future.

Fixes #329.