### PR TITLE
Fix build with mtl < v2.2.2

### DIFF
--- a/Text/Megaparsec/Class.hs
+++ b/Text/Megaparsec/Class.hs
@@ -14,6 +14,7 @@
 --
 -- @since 6.5.0
 
+{-# LANGUAGE CPP                    #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
@@ -38,6 +39,10 @@ import qualified Control.Monad.Trans.State.Lazy    as L
 import qualified Control.Monad.Trans.State.Strict  as S
 import qualified Control.Monad.Trans.Writer.Lazy   as L
 import qualified Control.Monad.Trans.Writer.Strict as S
+
+#if !MIN_VERSION_mtl(2,2,2)
+import Control.Monad.Trans.Identity
+#endif
 
 -- | Type class describing monads that implement the full set of primitive
 -- parsers.


### PR DESCRIPTION
Commit 56c89cba24903a966678c3508deeff8a0af0b68e removed a CPP
conditional.  mtl Control.Monad.Identity only exports
Control.Monad.Trans.Identity as of v2.2.2.  Therefore IdentityT is
not in scope with mtl < v2.2.2. and the build fails.

Restore the CPP block to fix building with mtl < v2.2.2.