### PR TITLE
Generalize numeric parsers in lexer modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Megaparec 7.1.0
+
+* Generalized `decimal`, `binary`, `octal`, and `hexadecimal` parsers in
+  lexer modules so that they `Num` instead of just `Integral`.
+
 ## Megaparsec 7.0.5
 
 * Dropped support for GHC 7.10.

--- a/Text/Megaparsec/Byte/Lexer.hs
+++ b/Text/Megaparsec/Byte/Lexer.hs
@@ -100,7 +100,7 @@ skipBlockCommentNested start end = p >> void (manyTill e n)
 -- If you need to parse signed integers, see the 'signed' combinator.
 
 decimal
-  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Integral a)
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Num a)
   => m a
 decimal = decimal_ <?> "integer"
 {-# INLINEABLE decimal #-}
@@ -108,7 +108,7 @@ decimal = decimal_ <?> "integer"
 -- | A non-public helper to parse decimal integers.
 
 decimal_
-  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Integral a)
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Num a)
   => m a
 decimal_ = mkNum <$> takeWhile1P (Just "digit") isDigit
   where
@@ -126,7 +126,7 @@ decimal_ = mkNum <$> takeWhile1P (Just "digit") isDigit
 -- @since 7.0.0
 
 binary
-  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Integral a)
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Num a)
   => m a
 binary = mkNum
   <$> takeWhile1P Nothing isBinDigit
@@ -148,7 +148,7 @@ binary = mkNum
 -- > octal = char 48 >> char' 111 >> L.octal
 
 octal
-  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Integral a)
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Num a)
   => m a
 octal = mkNum
   <$> takeWhile1P Nothing isOctDigit
@@ -170,7 +170,7 @@ octal = mkNum
 -- > hexadecimal = char 48 >> char' 120 >> L.hexadecimal
 
 hexadecimal
-  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Integral a)
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Word8, Num a)
   => m a
 hexadecimal = mkNum
   <$> takeWhile1P Nothing isHexDigit

--- a/Text/Megaparsec/Char/Lexer.hs
+++ b/Text/Megaparsec/Char/Lexer.hs
@@ -332,14 +332,14 @@ charLiteral = label "literal character" $ do
 -- __Note__: before version 6.0.0 the function returned 'Integer', i.e. it
 -- wasn't polymorphic in its return type.
 
-decimal :: (MonadParsec e s m, Token s ~ Char, Integral a) => m a
+decimal :: (MonadParsec e s m, Token s ~ Char, Num a) => m a
 decimal = decimal_ <?> "integer"
 {-# INLINEABLE decimal #-}
 
 -- | A non-public helper to parse decimal integers.
 
 decimal_
-  :: forall e s m a. (MonadParsec e s m, Token s ~ Char, Integral a)
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Char, Num a)
   => m a
 decimal_ = mkNum <$> takeWhile1P (Just "digit") Char.isDigit
   where
@@ -357,7 +357,7 @@ decimal_ = mkNum <$> takeWhile1P (Just "digit") Char.isDigit
 -- @since 7.0.0
 
 binary
-  :: forall e s m a. (MonadParsec e s m, Token s ~ Char, Integral a)
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Char, Num a)
   => m a
 binary = mkNum
   <$> takeWhile1P Nothing isBinDigit
@@ -382,7 +382,7 @@ binary = mkNum
 -- wasn't polymorphic in its return type.
 
 octal
-  :: forall e s m a. (MonadParsec e s m, Token s ~ Char, Integral a)
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Char, Num a)
   => m a
 octal = mkNum
   <$> takeWhile1P Nothing Char.isOctDigit
@@ -406,7 +406,7 @@ octal = mkNum
 -- wasn't polymorphic in its return type.
 
 hexadecimal
-  :: forall e s m a. (MonadParsec e s m, Token s ~ Char, Integral a)
+  :: forall e s m a. (MonadParsec e s m, Token s ~ Char, Num a)
   => m a
 hexadecimal = mkNum
   <$> takeWhile1P Nothing Char.isHexDigit


### PR DESCRIPTION
Close #356.

It appears that we can relax constraints for `decimal`, `binary`, `octal`, and `hexadecimal` from `Integral` to `Num` keeping the same implementations.