### PR TITLE
Simplify type signatures of ‘reachOffset’ and ‘reachOffsetNoLine’

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Megaparec 8.0.0
+
+* Changed type signatures of `reachOffset` and `reachOffsetNoLine` methods
+  of the `Stream` type class. Instead of three-tuple `reachOffset` now
+  returns two-tuple because `SourcePos` is already contained in the returned
+  `PosState` record.
+
 ## Megaparec 7.1.0
 
 * Generalized `decimal`, `binary`, `octal`, and `hexadecimal` parsers in

--- a/Text/Megaparsec.hs
+++ b/Text/Megaparsec.hs
@@ -529,9 +529,9 @@ setInput s = updateParserState (\(State _ o pst) -> State s o pst)
 getSourcePos :: MonadParsec e s m => m SourcePos
 getSourcePos = do
   st <- getParserState
-  let (pos, pst) = reachOffsetNoLine (stateOffset st) (statePosState st)
+  let pst = reachOffsetNoLine (stateOffset st) (statePosState st)
   setParserState st { statePosState = pst }
-  return pos
+  return (pstateSourcePos pst)
 {-# INLINE getSourcePos #-}
 
 -- | Get the number of tokens processed so far.

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -290,9 +290,9 @@ attachSourcePos projectOffset xs = runState (traverse f xs)
   where
     f a = do
       pst <- get
-      let (spos, pst') = reachOffsetNoLine (projectOffset a) pst
+      let pst' = reachOffsetNoLine (projectOffset a) pst
       put pst'
-      return (a, spos)
+      return (a, pstateSourcePos pst')
 {-# INLINEABLE attachSourcePos #-}
 
 ----------------------------------------------------------------------------
@@ -341,7 +341,8 @@ errorBundlePretty ParseErrorBundle {..} =
       -> (ShowS, PosState s)
     f (o, !pst) e = (o . (outChunk ++), pst')
       where
-        (epos, sline, pst') = reachOffset (errorOffset e) pst
+        (sline, pst') = reachOffset (errorOffset e) pst
+        epos = pstateSourcePos pst'
         outChunk =
           "\n" <> sourcePosPretty epos <> ":\n" <>
           padding <> "|\n" <>

--- a/megaparsec-tests/src/Test/Hspec/Megaparsec/AdHoc.hs
+++ b/megaparsec-tests/src/Test/Hspec/Megaparsec/AdHoc.hs
@@ -217,7 +217,7 @@ scaleDown = scale (`div` 4)
 
 strSourcePos :: Pos -> SourcePos -> String -> SourcePos
 strSourcePos tabWidth ipos input =
-  let (x, _, _) = reachOffset maxBound pstate in x
+  let (_, pst') = reachOffset maxBound pstate in pstateSourcePos pst'
   where
     pstate = PosState
       { pstateInput = input

--- a/megaparsec-tests/tests/Text/Megaparsec/ErrorSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/ErrorSpec.hs
@@ -83,9 +83,9 @@ spec = do
             pst' =
               if null xs
                 then pst
-                else snd $ reachOffsetNoLine (last xs) pst
+                else reachOffsetNoLine (last xs) pst
             rs = f <$> xs
-            f x = (x, fst (reachOffsetNoLine x pst))
+            f x = (x, pstateSourcePos (reachOffsetNoLine x pst))
         attachSourcePos id (xs :: [Int]) pst `shouldBe` (rs, pst')
 
   describe "errorBundlePretty" $ do

--- a/megaparsec-tests/tests/Text/Megaparsec/StreamSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/StreamSpec.hs
@@ -404,7 +404,7 @@ describeReachOffset Proxy =
               { pstateInput = "\n" :: s
               }
             o = pstateOffset pst + 1
-            (r, _, _) = reachOffset o pst
+            r = pstateSourcePos . snd $ reachOffset o pst
             SourcePos n l _ = pstateSourcePos pst
         r `shouldBe` SourcePos n (l <> pos1) pos1
     it "returns correct SourcePos (tab)" $
@@ -413,7 +413,7 @@ describeReachOffset Proxy =
               { pstateInput = "\t" :: s
               }
             o = pstateOffset pst + 1
-            (r, _, _) = reachOffset o pst
+            r = pstateSourcePos . snd $ reachOffset o pst
             SourcePos n l c = pstateSourcePos pst
             w = pstateTabWidth pst
         r `shouldBe` SourcePos n l (toNextTab w c)
@@ -423,7 +423,7 @@ describeReachOffset Proxy =
               { pstateInput = "a" :: s
               }
             o = pstateOffset pst + 1
-            (r, _, _) = reachOffset o pst
+            r = pstateSourcePos . snd $ reachOffset o pst
             SourcePos n l c = pstateSourcePos pst
         r `shouldBe` SourcePos n l (c <> pos1)
     it "replaces empty line with <empty line>" $
@@ -432,7 +432,7 @@ describeReachOffset Proxy =
               { pstateInput = "" :: s
               , pstateLinePrefix = ""
               }
-            (_, r, _) = reachOffset o pst
+            (r, _) = reachOffset o pst
         r `shouldBe` "<empty line>"
     it "replaces tabs with spaces in returned line" $
       property $ \pst' -> do
@@ -440,7 +440,7 @@ describeReachOffset Proxy =
               { pstateInput = "\ta\t" :: s
               , pstateLinePrefix = "\t"
               }
-            (_, r, _) = reachOffset 2 pst
+            (r, _) = reachOffset 2 pst
             w = unPos (pstateTabWidth pst)
             r' = replicate (w * 2) ' ' ++ "a" ++ replicate w ' '
         r `shouldBe` r'
@@ -450,7 +450,7 @@ describeReachOffset Proxy =
               { pstateInput = "foo\nbar\nbaz" :: s
               , pstateLinePrefix = "123"
               }
-            (_, r, _) = reachOffset 0 pst
+            (r, _) = reachOffset 0 pst
         r `shouldBe` "123foo"
     it "returns correct line (without line prefix)" $
       property $ \pst' -> do
@@ -458,7 +458,7 @@ describeReachOffset Proxy =
               { pstateInput = "foo\nbar\nbaz" :: s
               , pstateOffset = 0
               }
-            (_, r, _) = reachOffset 4 pst
+            (r, _) = reachOffset 4 pst
         r `shouldBe` "bar"
     it "works incrementally" $
       property $ \os' (NonNegative d) s -> do
@@ -469,7 +469,7 @@ describeReachOffset Proxy =
                    [] -> d
                    xs -> maximum xs + d
             f pst o =
-              let (_, _, pst') = reachOffset o pst
+              let (_, pst') = reachOffset o pst
               in pst'
         reachOffset o' s `shouldBe` reachOffset o' s'
 
@@ -491,7 +491,7 @@ describeReachOffsetNoLine Proxy =
               { pstateInput = "\n" :: s
               }
             o = pstateOffset pst + 1
-            (r, _) = reachOffsetNoLine o pst
+            r = pstateSourcePos (reachOffsetNoLine o pst)
             SourcePos n l _ = pstateSourcePos pst
         r `shouldBe` SourcePos n (l <> pos1) pos1
     it "returns correct SourcePos (tab)" $
@@ -500,7 +500,7 @@ describeReachOffsetNoLine Proxy =
               { pstateInput = "\t" :: s
               }
             o = pstateOffset pst + 1
-            (r, _) = reachOffsetNoLine o pst
+            r = pstateSourcePos (reachOffsetNoLine o pst)
             SourcePos n l c = pstateSourcePos pst
             w = pstateTabWidth pst
         r `shouldBe` SourcePos n l (toNextTab w c)
@@ -510,7 +510,7 @@ describeReachOffsetNoLine Proxy =
               { pstateInput = "a" :: s
               }
             o = pstateOffset pst + 1
-            (r, _) = reachOffsetNoLine o pst
+            r = pstateSourcePos (reachOffsetNoLine o pst)
             SourcePos n l c = pstateSourcePos pst
         r `shouldBe` SourcePos n l (c <> pos1)
     it "works incrementally" $
@@ -522,7 +522,7 @@ describeReachOffsetNoLine Proxy =
                    [] -> d
                    xs -> maximum xs + d
             f pst o =
-              let (_, pst') = reachOffsetNoLine o pst
+              let pst' = reachOffsetNoLine o pst
               in pst'
         reachOffsetNoLine o' s `shouldBe` reachOffsetNoLine o' s'
 

--- a/megaparsec-tests/tests/Text/MegaparsecSpec.hs
+++ b/megaparsec-tests/tests/Text/MegaparsecSpec.hs
@@ -1247,7 +1247,8 @@ spec = do
         property $ \st -> do
           let p :: Parser SourcePos
               p = getSourcePos
-              (spos, _, pst') = reachOffset (stateOffset st) (statePosState st)
+              pst' = snd $ reachOffset (stateOffset st) (statePosState st)
+              spos = pstateSourcePos pst'
           runParser' p st `shouldBe` (st { statePosState = pst' }, Right spos)
 
     describe "setOffset and getOffset" $


### PR DESCRIPTION
Close #344.

Changed type signatures of `reachOffset` and `reachOffsetNoLine` methods of the `Stream` type class. Instead of three-tuple `reachOffset` now returns two-tuple because `SourcePos` is already contained in the returned `PosState` record.