### PR TITLE
[RFC] Memoization and backtracking frames

### DIFF
--- a/Text/Megaparsec/Debug.hs
+++ b/Text/Megaparsec/Debug.hs
@@ -62,22 +62,22 @@ dbg :: forall e s m a.
   => String            -- ^ Debugging label
   -> ParsecT e s m a   -- ^ Parser to debug
   -> ParsecT e s m a   -- ^ Parser that prints debugging messages
-dbg lbl p = ParsecT $ \s cok cerr eok eerr ->
+dbg lbl p = ParsecT $ \s mm cok cerr eok eerr ->
   let l = dbgLog lbl :: DbgItem s e a -> String
       unfold = streamTake 40
-      cok' x s' hs = flip trace (cok x s' hs) $
+      cok' x s' hs mm' = flip trace (cok x s' hs mm') $
         l (DbgIn (unfold (stateInput s))) ++
         l (DbgCOK (streamTake (streamDelta s s') (stateInput s)) x)
-      cerr' err s' = flip trace (cerr err s') $
+      cerr' err s' mm' = flip trace (cerr err s' mm') $
         l (DbgIn (unfold (stateInput s))) ++
         l (DbgCERR (streamTake (streamDelta s s') (stateInput s)) err)
-      eok' x s' hs = flip trace (eok x s' hs) $
+      eok' x s' hs mm' = flip trace (eok x s' hs mm') $
         l (DbgIn (unfold (stateInput s))) ++
         l (DbgEOK (streamTake (streamDelta s s') (stateInput s)) x)
-      eerr' err s' = flip trace (eerr err s') $
+      eerr' err s' mm' = flip trace (eerr err s' mm') $
         l (DbgIn (unfold (stateInput s))) ++
         l (DbgEERR (streamTake (streamDelta s s') (stateInput s)) err)
-  in unParser p s cok' cerr' eok' eerr'
+  in unParser p s mm cok' cerr' eok' eerr'
 
 -- | A single piece of info to be rendered with 'dbgLog'.
 

--- a/Text/Megaparsec/Internal/TagMap.hs
+++ b/Text/Megaparsec/Internal/TagMap.hs
@@ -1,0 +1,96 @@
+-- |
+-- Module      :  Text.Megaparsec.Internal.TagMap
+-- Copyright   :  © 2019 Megaparsec contributors
+-- License     :  FreeBSD
+--
+-- Maintainer  :  Mark Karpov <markkarpov92@gmail.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Internal definitions. Versioning rules do not apply here. Please do not
+-- rely on these unless you really know what you're doing.
+--
+-- @since 8.0.0
+
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE Rank2Types                 #-}
+
+module Text.Megaparsec.Internal.TagMap
+  ( -- * Data types
+    Tag
+  , TagMap
+    -- * Helper functions
+  , makeTag
+  , insert
+  , singleton
+  , Text.Megaparsec.Internal.TagMap.lookup
+  , tmap
+    -- * Implementation-specific types and helpers
+  , SomeTag
+  , looseTag )
+where
+
+import Data.Foldable
+import System.Mem.StableName (StableName, makeStableName, eqStableName)
+import System.IO.Unsafe (unsafePerformIO)
+import GHC.Exts (Any)
+import Unsafe.Coerce (unsafeCoerce)
+
+-- | A TagMap is used for memoization. It associates tags
+-- (based on 'StableName's) with an associated value of the same
+-- type.
+newtype TagMap f = TagMap { unTagMap :: [(SomeTag f, f Any)] }
+
+-- | Value tag used for memoization
+newtype Tag f a = Tag { unTag :: StableName (f a) }
+
+-- | Value tag with its inner type @a@ hidden.
+data SomeTag f = forall a. SomeTag (StableName (f a))
+
+-- | Convert the outer type @f@ of some TagMap into another type @f'@.
+tmap :: forall f f'. (forall a. f a -> f' a) -> TagMap f -> TagMap f'
+tmap f = TagMap . fmap f' . unTagMap
+  where
+    f' :: (SomeTag f, f Any) -> (SomeTag f', f' Any)
+    -- This unsafeCoerce is harmless, since the StableName type variable
+    -- actually has a phantom role (this is going to be fixed in GHC 8.8)
+    -- This is because StableNames operate on values, not types, and
+    -- two values of different types can never have the same StableName.
+    f' (SomeTag k, v) = (SomeTag (unsafeCoerce k), f v)
+
+-- | Tag equality based on stable name equality ('eqStableName').
+instance Eq (SomeTag f) where
+  -- Note: This works even though the SomeTags are existentially qualified
+  -- because eqStableName does not care about the StableName type variable.
+  (SomeTag lhs) == (SomeTag rhs) = lhs `eqStableName` rhs
+
+-- | Forget the inner type @a@ of some @Tag f a@ by transforming it into
+-- a @SomeTag f@.
+looseTag :: Tag f a -> SomeTag f
+looseTag = SomeTag . unTag
+
+-- | Tag a value.
+makeTag :: f a -> Tag f a
+makeTag !p = Tag . unsafePerformIO . makeStableName $ p
+{-# NOINLINE makeTag #-}
+
+-- | /O(1)/. A @'TagMap' f@ with only one element.
+singleton :: Functor f => Tag f v -> f v -> TagMap f
+singleton !(looseTag -> k) (fmap unsafeCoerce -> v) = TagMap [(k, v)]
+{-# INLINE singleton #-}
+
+-- | /O(1)/. Insert a new element into a @'TagMap' f@. Does not check for duplicates.
+insert :: Functor f => Tag f v -> f v -> TagMap f -> TagMap f
+insert !(looseTag -> k) (fmap unsafeCoerce -> v) = TagMap . ((k, v):) . unTagMap
+{-# INLINE insert #-}
+
+-- | /O(n)/. Look up a value @f v@ associated with some @'Tag' f v@.
+lookup :: forall f v. Functor f => Tag f v -> TagMap f -> Maybe (f v)
+lookup !(looseTag -> k) = fmap conv . find ((== k) . fst) . unTagMap
+  where
+    conv :: (SomeTag f, f Any) -> f v
+    conv = fmap unsafeCoerce . snd
+{-# INLINE lookup #-}

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -52,6 +52,7 @@ library
                     , Text.Megaparsec.Error
                     , Text.Megaparsec.Error.Builder
                     , Text.Megaparsec.Internal
+                    , Text.Megaparsec.Internal.TagMap
                     , Text.Megaparsec.Pos
                     , Text.Megaparsec.Stream
   other-modules:      Text.Megaparsec.Class


### PR DESCRIPTION
This is a request for comments on an experimental modification to Megaparsec that allows memoization of parsing results. There are still a number of rough edges around so this is not ready to be merged, but I would be grateful for feedback!
Overview of the changes:

1. A new combinator `memo :: m a -> m a` that memoizes a parser.
2. A new type `Memo e s m` that includes the actual memoization table and is passed around similar to the parsing state `State s`, but with some differences (e.g. when doing lookahead, we want to keep the memoization results but discard the resulting state).
3. The memoization table is implemented using a two-level map. The first level is an ordinary `IntMap` for looking up results based on token offset. The second level is a special data structure called `TagMap f` (open to suggestions on better names!). The idea behind that is that we want to associate parsers with their results at a specific token offset, and we need a way to identify different parsers. It is not enough to rely on a parser's type alone because different parsers can still have identical types, so we have to identify parsers by "value". This is not quite straightforward because a `ParsecT e s m a` is really just a CPS function. Fortunately, there is a way out: Using `StableName`s. They uniquely identify a value.
Essentially, a `TagMap f` associates a `StableName (f a)` with a value `f a`, but with a twist: We need to store parsers that return different result types in our memo table - otherwise, it would be useless. So the result type `a` is hidden using a combination of existential quantification and unsafe coercions to and from `Any`. The latter look scary, but they should be harmless since if two values have the same `StableName`, they are guaranteed to have the same type.
Note that we could completely remove `f` (which is `ParsecT e s m` in this case) and just use `a`. Why do we keep track of `f` at all then? The answer lies in type safety: By tracking the outer type `f`, we make sure that two memo tables with different type error/stream/underlying monad types are not compatible.
This version of the `TagMap` is the result of a number of rounds of completely reimplementing the memoization table, and I'm reasonably confident that this version is a good compromise.
4. Aside from memoization, this PR also includes a system to keep track of (nested) backtracking called "backtracking frames".
The main reason I implemented this was to save some space by discarding memo entries that are no longer required: If we leave the topmost frame, we are committed to that token offset, i.e. we will never look at tokens before the current offset, so we can remove all memo entries with an offset smaller than the current offset.
This has other benefits as well: By adding an extra `frameCommitted` bool to the frame data structure, we can easily add the `commit` operator (see #315). When starting a new frame (in `try`), we set the `frameCommitted` field to false. The new `commit` combinator just sets the current frame's `frameCommitted` field to true. When leaving the frame, we check whether the `frameCommitted` field is true. If it is, the frame was committed and we act as if we weren't backtracking at all. If it is not, we backtrack normally.

The performance benefits are promising. I've done some (limited) benchmarking and the results are as expected, i.e. there are no measurable performance penalties when you're not actually using memoization, but if you're memoizing often-reparsed parsers, parsing will be considerably faster (especially if your parsers are doing a lot of backtracking).

Open questions:
1. The `TagMap f` data structure is an ideal candidate for a `HashMap`. I didn't use it because it would incur an additional dependency on `unordered-containers`. Additionally, if the number of memoized results per offset is small (which is my expectation), the constant overhead of `HashMap`s could be significant compared to a simple linked list.
2. As noted in the documentation for `memo`, there are some possible issues regarding stateful monads as the underlying `ParsecT` monad. There might be further implications I'm not aware of.
3. I've initially added the backtracking frame system to the `Memo` type, but it might be better to move the frames to the main `State` type.
4. It's not quite clear what the correct behaviour of `withParsecT` should be. Currently, it maps the memo  entries using the supplied error type conversion function. Should `withParsecT` instead discard any memo entries? I'm not even sure what the intended use of `withParsecT` is.
5. It might be a better idea to add a new type `MemoParsecT e s m a` in addition to the standard `ParsecT e s m a` and only implement memoization for the former. This is possible since memoization should be transparent and `memo = id` is a valid implementation for `memo :: m a -> m a`, so the normal `ParsecT e s m a` can pretend to implement `memo` as well. Users could choose to utilize memoization by changing their parser type.
6. During debugging, I sprinkled some bang patterns here and there. Most of them had a positive impact when I inserted them, but some could certainly be removed again.

A possible future addition is incremental parsing. The idea is quite simple: Instead of discarding the memo table after parsing, it is kept around and reused when re-parsing the edited input. The only issue is determining which memo entries are affected by an edit operation and invalidating them. See https://ohmlang.github.io/pubs/sle2017/incremental-packrat-parsing.pdf for an in-depth introduction to the topic.
See https://blog.mattbierner.com/memoization-in-parse/ for a comparable implementation of memoization in a CPS parser combinator library. Some of the design choices I made were based on that article, including the explicit `memo` combinator and backtracking frames (called memoization window in the article).