### PR TITLE
Allow Stream to specify custom token width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Megaparec 8.0.0
 
+* Added the `tokensLength` method to the `Stream` type class to improve
+  support for custom input streams.
+
 * Changed type signatures of `reachOffset` and `reachOffsetNoLine` methods
   of the `Stream` type class. Instead of three-tuple `reachOffset` now
   returns two-tuple because `SourcePos` is already contained in the returned

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -357,10 +357,11 @@ errorBundlePretty ParseErrorBundle {..} =
             then slineLen - rpshift + 1
             else elen
         slineLen = length sline
+        pxy = Proxy :: Proxy s
         elen =
           case e of
             TrivialError _ Nothing _ -> 1
-            TrivialError _ (Just x) _ -> errorItemLength x
+            TrivialError _ (Just x) _ -> errorItemLength pxy x
             FancyError _ xs ->
               E.foldl' (\a b -> max a (errorFancyLength b)) 1 xs
 
@@ -411,9 +412,9 @@ showErrorItem pxy = \case
 
 -- | Get length of the “pointer” to display under a given 'ErrorItem'.
 
-errorItemLength :: ErrorItem t -> Int
-errorItemLength = \case
-  Tokens ts -> NE.length ts
+errorItemLength :: Stream s => Proxy s -> ErrorItem (Token s) -> Int
+errorItemLength pxy = \case
+  Tokens ts -> tokensLength pxy ts
   _         -> 1
 
 -- | Pretty-print an 'ErrorFancy'.

--- a/Text/Megaparsec/Stream.hs
+++ b/Text/Megaparsec/Stream.hs
@@ -132,6 +132,15 @@ class (Ord (Token s), Ord (Tokens s)) => Stream s where
 
   showTokens :: Proxy s -> NonEmpty (Token s) -> String
 
+  -- | Return the number of characters that a non-empty stream of tokens
+  -- spans. The default implementation is sufficient if every token spans
+  -- exactly 1 character.
+  --
+  -- @since 8.0.0
+
+  tokensLength :: Proxy s -> NonEmpty (Token s) -> Int
+  tokensLength Proxy = NE.length
+
   -- | Given an offset @o@ and initial 'PosState', adjust the state in such
   -- a way that it starts at the offset.
   --


### PR DESCRIPTION
Currently, the `errorItemLength` function implicitly assumes that every token spans exactly one character. That assumption is correct for the `Stream` instances for the basic string types (`String`/`Text`/`ByteString`) included in Megaparsec. It does not necessarily hold for custom token types however, in particular if using a separate lexer pass.

This commit adds a new `tokensLength` function that allows the `Stream` instance to give a custom width for a non-empty token stream.

In practice, parse errors concerning a token with a width greater than 1 are currently rendered incorrectly (only one caret is displayed below the offending token).