### PR TITLE
Drop remaining CPP, drop support for GHC 8.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,10 @@ cache:
 
 matrix:
   include:
-    - env: CABALVER=2.4 GHCVER=8.2.2
-      addons: {apt: {packages: [cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}
-    - env: CABALVER=2.4 GHCVER=8.4.4
-      addons: {apt: {packages: [cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
-    - env: CABALVER=2.4 GHCVER=8.6.5
-      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
+    - env: CABALVER=3.0 GHCVER=8.4.4
+      addons: {apt: {packages: [cabal-install-3.0,ghc-8.4.4], sources: [hvr-ghc]}}
+    - env: CABALVER=3.0 GHCVER=8.6.5
+      addons: {apt: {packages: [cabal-install-3.0,ghc-8.6.5], sources: [hvr-ghc]}}
 
 before_install:
   - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
@@ -29,8 +27,8 @@ script:
   - cabal new-test megaparsec-tests --enable-tests --enable-benchmarks --flags=dev
   - cabal new-haddock megaparsec
   - cabal new-haddock megaparsec-tests
-  - cabal sdist
-  - cd megaparsec-tests && cabal sdist
+  - cabal new-sdist
+  - cd megaparsec-tests && cabal new-sdist
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   returns two-tuple because `SourcePos` is already contained in the returned
   `PosState` record.
 
+* Dropped support for GHC 8.2.x.
+
 ## Megaparec 7.1.0
 
 * Generalized `decimal`, `binary`, `octal`, and `hexadecimal` parsers in

--- a/Text/Megaparsec/Class.hs
+++ b/Text/Megaparsec/Class.hs
@@ -14,7 +14,6 @@
 --
 -- @since 6.5.0
 
-{-# LANGUAGE CPP                    #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
@@ -39,10 +38,6 @@ import qualified Control.Monad.Trans.State.Lazy    as L
 import qualified Control.Monad.Trans.State.Strict  as S
 import qualified Control.Monad.Trans.Writer.Lazy   as L
 import qualified Control.Monad.Trans.Writer.Strict as S
-
-#if !MIN_VERSION_mtl(2,2,2)
-import Control.Monad.Trans.Identity
-#endif
 
 -- | Type class describing monads that implement the full set of primitive
 -- parsers.

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -16,7 +16,6 @@
 -- "Text.Megaparsec" re-exports it anyway.
 
 {-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE DeriveGeneric       #-}
@@ -61,10 +60,6 @@ import Text.Megaparsec.State
 import Text.Megaparsec.Stream
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set           as E
-
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup
-#endif
 
 ----------------------------------------------------------------------------
 -- Parse error type

--- a/Text/Megaparsec/Error/Builder.hs
+++ b/Text/Megaparsec/Error/Builder.hs
@@ -12,7 +12,6 @@
 --
 -- @since 6.0.0
 
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE DeriveDataTypeable   #-}
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleContexts     #-}
@@ -49,10 +48,6 @@ import Text.Megaparsec.Error
 import Text.Megaparsec.Stream
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set           as E
-
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup
-#endif
 
 ----------------------------------------------------------------------------
 -- Data types

--- a/Text/Megaparsec/Internal.hs
+++ b/Text/Megaparsec/Internal.hs
@@ -25,10 +25,6 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-#if !MIN_VERSION_base(4,11,0)
-{-# OPTIONS -Wno-noncanonical-monoid-instances #-}
-#endif
-
 module Text.Megaparsec.Internal
   ( -- * Data types
     Hints (..)
@@ -142,11 +138,7 @@ instance (Stream s, Semigroup a) => Semigroup (ParsecT e s m a) where
 instance (Stream s, Monoid a) => Monoid (ParsecT e s m a) where
   mempty = pure mempty
   {-# INLINE mempty #-}
-#if MIN_VERSION_base(4,11,0)
   mappend = (<>)
-#else
-  mappend = liftA2 mappend
-#endif
   {-# INLINE mappend #-}
   mconcat = fmap mconcat . sequence
   {-# INLINE mconcat #-}

--- a/Text/Megaparsec/Pos.hs
+++ b/Text/Megaparsec/Pos.hs
@@ -13,7 +13,6 @@
 -- You probably do not want to import this module directly because
 -- "Text.Megaparsec" re-exports it anyway.
 
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -37,10 +36,6 @@ import Control.Exception
 import Data.Data (Data)
 import Data.Typeable (Typeable)
 import GHC.Generics
-
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup
-#endif
 
 ----------------------------------------------------------------------------
 -- Abstract position

--- a/Text/Megaparsec/Stream.hs
+++ b/Text/Megaparsec/Stream.hs
@@ -14,7 +14,6 @@
 --
 -- @since 6.0.0
 
-{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE LambdaCase          #-}
@@ -43,10 +42,6 @@ import qualified Data.ByteString.Lazy.Char8 as BL8
 import qualified Data.List.NonEmpty         as NE
 import qualified Data.Text                  as T
 import qualified Data.Text.Lazy             as TL
-
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup
-#endif
 
 -- | Type class for inputs that can be consumed by the library.
 

--- a/megaparsec-tests/megaparsec-tests.cabal
+++ b/megaparsec-tests/megaparsec-tests.cabal
@@ -1,7 +1,7 @@
 name:                 megaparsec-tests
 version:              7.0.5
 cabal-version:        1.18
-tested-with:          GHC==8.2.2, GHC==8.4.4, GHC==8.6.5
+tested-with:          GHC==8.4.4, GHC==8.6.5, GHC==8.8.1
 license:              BSD2
 license-file:         LICENSE.md
 author:               Megaparsec contributors
@@ -21,15 +21,15 @@ flag dev
 
 library
   hs-source-dirs:     src
-  build-depends:      QuickCheck   >= 2.7   && < 2.14
-                    , base         >= 4.10  && < 5.0
+  build-depends:      QuickCheck   >= 2.10  && < 2.14
+                    , base         >= 4.11  && < 5.0
                     , bytestring   >= 0.2   && < 0.11
                     , containers   >= 0.5   && < 0.7
                     , hspec        >= 2.0   && < 3.0
                     , hspec-expectations >= 0.8 && < 0.9
                     , hspec-megaparsec >= 2.0 && < 3.0
                     , megaparsec   == 7.0.5
-                    , mtl          >= 2.0   && < 3.0
+                    , mtl          >= 2.2.2 && < 3.0
                     , text         >= 0.2   && < 1.3
                     , transformers >= 0.4   && < 0.6
   exposed-modules:    Test.Hspec.Megaparsec.AdHoc
@@ -60,8 +60,8 @@ test-suite tests
                     , Text.Megaparsec.PosSpec
                     , Text.Megaparsec.StreamSpec
                     , Text.MegaparsecSpec
-  build-depends:      QuickCheck   >= 2.7   && < 2.14
-                    , base         >= 4.10  && < 5.0
+  build-depends:      QuickCheck   >= 2.10  && < 2.14
+                    , base         >= 4.11  && < 5.0
                     , bytestring   >= 0.2   && < 0.11
                     , case-insensitive >= 1.2 && < 1.3
                     , containers   >= 0.5   && < 0.7
@@ -70,7 +70,7 @@ test-suite tests
                     , hspec-megaparsec >= 2.0 && < 3.0
                     , megaparsec   == 7.0.5
                     , megaparsec-tests
-                    , mtl          >= 2.0   && < 3.0
+                    , mtl          >= 2.2.2 && < 3.0
                     , parser-combinators >= 1.0 && < 2.0
                     , scientific   >= 0.3.1 && < 0.4
                     , text         >= 0.2   && < 1.3

--- a/megaparsec-tests/src/Test/Hspec/Megaparsec/AdHoc.hs
+++ b/megaparsec-tests/src/Test/Hspec/Megaparsec/AdHoc.hs
@@ -9,7 +9,6 @@
 --
 -- Ad-hoc helpers used in Megaparsec's test suite.
 
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
@@ -332,7 +331,5 @@ instance Arbitrary B.ByteString where
 instance Arbitrary BL.ByteString where
   arbitrary = BL.pack <$> arbitrary
 
-#if MIN_VERSION_QuickCheck(2,10,0)
 instance Arbitrary a => Arbitrary (NonEmpty a) where
   arbitrary = NE.fromList <$> (arbitrary `suchThat` (not . null))
-#endif

--- a/megaparsec-tests/tests/Text/Megaparsec/Char/LexerSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/Char/LexerSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP              #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiWayIf       #-}
 {-# LANGUAGE TupleSections    #-}

--- a/megaparsec-tests/tests/Text/Megaparsec/CharSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/CharSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP              #-}
 {-# OPTIONS -fno-warn-orphans #-}
 
 module Text.Megaparsec.CharSpec (spec) where

--- a/megaparsec-tests/tests/Text/Megaparsec/ErrorSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/ErrorSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Text.Megaparsec.ErrorSpec (spec) where
@@ -15,10 +14,6 @@ import Test.QuickCheck
 import Text.Megaparsec
 import qualified Data.Semigroup     as S
 import qualified Data.Set           as E
-
-#if !MIN_VERSION_base(4,11,0)
-import Data.Monoid
-#endif
 
 spec :: Spec
 spec = do

--- a/megaparsec-tests/tests/Text/MegaparsecSpec.hs
+++ b/megaparsec-tests/tests/Text/MegaparsecSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiWayIf        #-}
@@ -40,12 +39,6 @@ import qualified Data.List                   as DL
 import qualified Data.Semigroup              as G
 import qualified Data.Set                    as E
 import qualified Data.Text                   as T
-
-#if !MIN_VERSION_QuickCheck(2,8,2)
-instance (Arbitrary a, Ord a) => Arbitrary (E.Set a) where
-  arbitrary = E.fromList <$> arbitrary
-  shrink    = fmap E.fromList . shrink . E.toList
-#endif
 
 spec :: Spec
 spec = do

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -1,7 +1,7 @@
 name:                 megaparsec
 version:              7.0.5
 cabal-version:        1.18
-tested-with:          GHC==8.2.2, GHC==8.4.4, GHC==8.6.5
+tested-with:          GHC==8.4.4, GHC==8.6.5
 license:              BSD2
 license-file:         LICENSE.md
 author:               Megaparsec contributors,
@@ -33,12 +33,12 @@ flag dev
   default:            False
 
 library
-  build-depends:      base         >= 4.10  && < 5.0
+  build-depends:      base         >= 4.11  && < 5.0
                     , bytestring   >= 0.2   && < 0.11
                     , case-insensitive >= 1.2 && < 1.3
                     , containers   >= 0.5   && < 0.7
                     , deepseq      >= 1.3   && < 1.5
-                    , mtl          >= 2.0   && < 3.0
+                    , mtl          >= 2.2.2 && < 3.0
                     , parser-combinators >= 1.0 && < 2.0
                     , scientific   >= 0.3.1 && < 0.4
                     , text         >= 0.2   && < 1.3
@@ -74,7 +74,7 @@ benchmark bench-speed
   main-is:            Main.hs
   hs-source-dirs:     bench/speed
   type:               exitcode-stdio-1.0
-  build-depends:      base         >= 4.10  && < 5.0
+  build-depends:      base         >= 4.11  && < 5.0
                     , containers   >= 0.5  && < 0.7
                     , criterion    >= 0.6.2.1 && < 1.6
                     , deepseq      >= 1.3  && < 1.5
@@ -90,7 +90,7 @@ benchmark bench-memory
   main-is:            Main.hs
   hs-source-dirs:     bench/memory
   type:               exitcode-stdio-1.0
-  build-depends:      base         >= 4.10  && < 5.0
+  build-depends:      base         >= 4.11  && < 5.0
                     , containers   >= 0.5  && < 0.7
                     , deepseq      >= 1.3  && < 1.5
                     , megaparsec


### PR DESCRIPTION
Currently blocked on dependencies. In particular: https://github.com/bos/aeson/pull/697. Let's wait a bit.