### PR TITLE
Remove CPP from the library

### DIFF
--- a/Text/Megaparsec/Internal.hs
+++ b/Text/Megaparsec/Internal.hs
@@ -24,6 +24,7 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
+{-# OPTIONS_GHC -Wno-orphans            #-}
 
 module Text.Megaparsec.Internal
   ( -- * Data types
@@ -57,73 +58,17 @@ import Data.Set (Set)
 import Data.String (IsString (..))
 import Text.Megaparsec.Class
 import Text.Megaparsec.Error
+import Text.Megaparsec.Internal.Monad()
+import Text.Megaparsec.Internal.ParsecT
 import Text.Megaparsec.State
 import Text.Megaparsec.Stream
-import qualified Control.Monad.Fail  as Fail
 import qualified Data.List.NonEmpty  as NE
 import qualified Data.Set            as E
-
-----------------------------------------------------------------------------
--- Data types
-
--- | 'Hints' represent a collection of 'ErrorItem's to be included into
--- 'ParseError' (when it's a 'TrivialError') as “expected” message items
--- when a parser fails without consuming input right after successful parser
--- that produced the hints.
---
--- For example, without hints you could get:
---
--- >>> parseTest (many (char 'r') <* eof) "ra"
--- 1:2:
--- unexpected 'a'
--- expecting end of input
---
--- We're getting better error messages with the help of hints:
---
--- >>> parseTest (many (char 'r') <* eof) "ra"
--- 1:2:
--- unexpected 'a'
--- expecting 'r' or end of input
-
-newtype Hints t = Hints [Set (ErrorItem t)]
-  deriving (Semigroup, Monoid)
-
--- | All information available after parsing. This includes consumption of
--- input, success (with returned value) or failure (with parse error), and
--- parser state at the end of parsing.
---
--- See also: 'Consumption', 'Result'.
-
-data Reply e s a = Reply (State s) Consumption (Result s e a)
-
--- | Whether the input has been consumed or not.
---
--- See also: 'Result', 'Reply'.
-
-data Consumption
-  = Consumed -- ^ Some part of input stream was consumed
-  | Virgin   -- ^ No input was consumed
 
 -- | Whether the parser has failed or not. On success we include the
 -- resulting value, on failure we include a 'ParseError'.
 --
 -- See also: 'Consumption', 'Reply'.
-
-data Result s e a
-  = OK a                   -- ^ Parser succeeded
-  | Error (ParseError s e) -- ^ Parser failed
-
--- | @'ParsecT' e s m a@ is a parser with custom data component of error
--- @e@, stream type @s@, underlying monad @m@ and return type @a@.
-
-newtype ParsecT e s m a = ParsecT
-  { unParser
-      :: forall b. State s
-      -> (a -> State s   -> Hints (Token s) -> m b) -- consumed-OK
-      -> (ParseError s e -> State s         -> m b) -- consumed-error
-      -> (a -> State s   -> Hints (Token s) -> m b) -- empty-OK
-      -> (ParseError s e -> State s         -> m b) -- empty-error
-      -> m b }
 
 -- | @since 5.3.0
 
@@ -149,73 +94,11 @@ instance (a ~ Tokens s, IsString a, Eq a, Stream s, Ord e)
     => IsString (ParsecT e s m a) where
   fromString s = tokens (==) (fromString s)
 
-instance Functor (ParsecT e s m) where
-  fmap = pMap
-
-pMap :: (a -> b) -> ParsecT e s m a -> ParsecT e s m b
-pMap f p = ParsecT $ \s cok cerr eok eerr ->
-  unParser p s (cok . f) cerr (eok . f) eerr
-{-# INLINE pMap #-}
-
--- | 'pure' returns a parser that __succeeds__ without consuming input.
-
-instance Stream s => Applicative (ParsecT e s m) where
-  pure     = pPure
-  (<*>)    = pAp
-  p1 *> p2 = p1 `pBind` const p2
-  p1 <* p2 = do { x1 <- p1 ; void p2 ; return x1 }
-
-pPure :: a -> ParsecT e s m a
-pPure x = ParsecT $ \s _ _ eok _ -> eok x s mempty
-{-# INLINE pPure #-}
-
-pAp :: Stream s
-  => ParsecT e s m (a -> b)
-  -> ParsecT e s m a
-  -> ParsecT e s m b
-pAp m k = ParsecT $ \s cok cerr eok eerr ->
-  let mcok x s' hs = unParser k s' (cok . x) cerr
-        (accHints hs (cok . x)) (withHints hs cerr)
-      meok x s' hs = unParser k s' (cok . x) cerr
-        (accHints hs (eok . x)) (withHints hs eerr)
-  in unParser m s mcok cerr meok eerr
-{-# INLINE pAp #-}
-
 -- | 'empty' is a parser that __fails__ without consuming input.
 
 instance (Ord e, Stream s) => Alternative (ParsecT e s m) where
   empty  = mzero
   (<|>)  = mplus
-
--- | 'return' returns a parser that __succeeds__ without consuming input.
-
-instance Stream s => Monad (ParsecT e s m) where
-  return = pure
-  (>>=)  = pBind
-#if !(MIN_VERSION_base(4,13,0))
-  fail   = Fail.fail
-#endif
-
-pBind :: Stream s
-  => ParsecT e s m a
-  -> (a -> ParsecT e s m b)
-  -> ParsecT e s m b
-pBind m k = ParsecT $ \s cok cerr eok eerr ->
-  let mcok x s' hs = unParser (k x) s' cok cerr
-        (accHints hs cok) (withHints hs cerr)
-      meok x s' hs = unParser (k x) s' cok cerr
-        (accHints hs eok) (withHints hs eerr)
-  in unParser m s mcok cerr meok eerr
-{-# INLINE pBind #-}
-
-instance Stream s => Fail.MonadFail (ParsecT e s m) where
-  fail = pFail
-
-pFail :: String -> ParsecT e s m a
-pFail msg = ParsecT $ \s@(State _ o _) _ _ _ eerr ->
-  let d = E.singleton (ErrorFail msg)
-  in eerr (FancyError o d) s
-{-# INLINE pFail #-}
 
 instance (Stream s, MonadIO m) => MonadIO (ParsecT e s m) where
   liftIO = lift . liftIO
@@ -298,10 +181,6 @@ instance (Stream s, MonadFix m) => MonadFix (ParsecT e s m) where
         OK a' -> a'
         Error _ -> error "mfix ParsecT"
     runParsecT (f a) s
-
-instance MonadTrans (ParsecT e s) where
-  lift amb = ParsecT $ \s _ _ eok _ ->
-    amb >>= \a -> eok a s mempty
 
 instance (Ord e, Stream s) => MonadParsec e s (ParsecT e s m) where
   failure           = pFailure
@@ -531,90 +410,3 @@ pUpdateParserState f = ParsecT $ \s _ _ eok _ -> eok () (f s) mempty
 nes :: a -> NonEmpty a
 nes x = x :| []
 {-# INLINE nes #-}
-
-----------------------------------------------------------------------------
--- Helper functions
-
--- | Convert 'ParseError' record to 'Hints'.
-
-toHints
-  :: Stream s
-  => Int               -- ^ Current offset in input stream
-  -> ParseError s e    -- ^ Parse error to convert
-  -> Hints (Token s)
-toHints streamPos = \case
-  TrivialError errOffset _ ps ->
-    -- NOTE This is important to check here that the error indeed has
-    -- happened at the same position as current position of stream because
-    -- there might have been backtracking with 'try' and in that case we
-    -- must not convert such a parse error to hints.
-    if streamPos == errOffset
-      then Hints (if E.null ps then [] else [ps])
-      else mempty
-  FancyError _ _ -> mempty
-{-# INLINE toHints #-}
-
--- | @'withHints' hs c@ makes “error” continuation @c@ use given hints @hs@.
---
--- Note that if resulting continuation gets 'ParseError' that has custom
--- data in it, hints are ignored.
-
-withHints
-  :: Stream s
-  => Hints (Token s)   -- ^ Hints to use
-  -> (ParseError s e -> State s -> m b) -- ^ Continuation to influence
-  -> ParseError s e    -- ^ First argument of resulting continuation
-  -> State s           -- ^ Second argument of resulting continuation
-  -> m b
-withHints (Hints ps') c e =
-  case e of
-    TrivialError pos us ps -> c (TrivialError pos us (E.unions (ps : ps')))
-    _ -> c e
-{-# INLINE withHints #-}
-
--- | @'accHints' hs c@ results in “OK” continuation that will add given
--- hints @hs@ to third argument of original continuation @c@.
-
-accHints
-  :: Hints t           -- ^ 'Hints' to add
-  -> (a -> State s -> Hints t -> m b) -- ^ An “OK” continuation to alter
-  -> (a -> State s -> Hints t -> m b) -- ^ Altered “OK” continuation
-accHints hs1 c x s hs2 = c x s (hs1 <> hs2)
-{-# INLINE accHints #-}
-
--- | Replace the most recent group of hints (if any) with the given
--- 'ErrorItem' (or delete it if 'Nothing' is given). This is used in the
--- 'label' primitive.
-
-refreshLastHint :: Hints t -> Maybe (ErrorItem t) -> Hints t
-refreshLastHint (Hints [])     _        = Hints []
-refreshLastHint (Hints (_:xs)) Nothing  = Hints xs
-refreshLastHint (Hints (_:xs)) (Just m) = Hints (E.singleton m : xs)
-{-# INLINE refreshLastHint #-}
-
--- | Low-level unpacking of the 'ParsecT' type.
-
-runParsecT :: Monad m
-  => ParsecT e s m a -- ^ Parser to run
-  -> State s       -- ^ Initial state
-  -> m (Reply e s a)
-runParsecT p s = unParser p s cok cerr eok eerr
-  where
-    cok a s' _  = return $ Reply s' Consumed (OK a)
-    cerr err s' = return $ Reply s' Consumed (Error err)
-    eok a s' _  = return $ Reply s' Virgin   (OK a)
-    eerr err s' = return $ Reply s' Virgin   (Error err)
-
--- | Transform any custom errors thrown by the parser using the given
--- function. Similar in function and purpose to @withExceptT@.
---
--- @since 7.0.0
-
-withParsecT :: (Monad m, Ord e')
-  => (e -> e')
-  -> ParsecT e s m a
-  -> ParsecT e' s m a
-withParsecT f p =
-  ParsecT $ \s cok cerr eok eerr ->
-    unParser p s cok (cerr . mapParseError f) eok (eerr . mapParseError f)
-{-# INLINE withParsecT #-}

--- a/Text/Megaparsec/Internal/ParsecT.hs
+++ b/Text/Megaparsec/Internal/ParsecT.hs
@@ -1,0 +1,254 @@
+-- |
+-- Module      :  Text.Megaparsec.Internal
+-- Copyright   :  © 2015–present Megaparsec contributors
+--                © 2007 Paolo Martini
+--                © 1999–2001 Daan Leijen
+-- License     :  FreeBSD
+--
+-- Maintainer  :  Mark Karpov <markkarpov92@gmail.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Internal definitions. Versioning rules do not apply here. Please do not
+-- rely on these unless you really know what you're doing.
+--
+-- @since 6.5.0
+
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+module Text.Megaparsec.Internal.ParsecT
+  ( -- * Data types
+    Hints (..)
+  , Reply (..)
+  , Consumption (..)
+  , Result (..)
+  , ParsecT (..)
+    -- * Helper functions
+  , toHints
+  , withHints
+  , accHints
+  , refreshLastHint
+  , runParsecT
+  , withParsecT
+  , pBind
+  , pFail )
+where
+
+import Control.Monad
+import Control.Monad.Trans
+import Data.Set (Set)
+import Text.Megaparsec.Error
+import Text.Megaparsec.State
+import Text.Megaparsec.Stream
+import qualified Data.Set            as E
+
+----------------------------------------------------------------------------
+-- Data types
+
+-- | 'Hints' represent a collection of 'ErrorItem's to be included into
+-- 'ParseError' (when it's a 'TrivialError') as “expected” message items
+-- when a parser fails without consuming input right after successful parser
+-- that produced the hints.
+--
+-- For example, without hints you could get:
+--
+-- >>> parseTest (many (char 'r') <* eof) "ra"
+-- 1:2:
+-- unexpected 'a'
+-- expecting end of input
+--
+-- We're getting better error messages with the help of hints:
+--
+-- >>> parseTest (many (char 'r') <* eof) "ra"
+-- 1:2:
+-- unexpected 'a'
+-- expecting 'r' or end of input
+
+newtype Hints t = Hints [Set (ErrorItem t)]
+  deriving (Semigroup, Monoid)
+
+-- | All information available after parsing. This includes consumption of
+-- input, success (with returned value) or failure (with parse error), and
+-- parser state at the end of parsing.
+--
+-- See also: 'Consumption', 'Result'.
+
+data Reply e s a = Reply (State s) Consumption (Result s e a)
+
+-- | Whether the input has been consumed or not.
+--
+-- See also: 'Result', 'Reply'.
+
+data Consumption
+  = Consumed -- ^ Some part of input stream was consumed
+  | Virgin   -- ^ No input was consumed
+
+-- | Whether the parser has failed or not. On success we include the
+-- resulting value, on failure we include a 'ParseError'.
+--
+-- See also: 'Consumption', 'Reply'.
+
+data Result s e a
+  = OK a                   -- ^ Parser succeeded
+  | Error (ParseError s e) -- ^ Parser failed
+
+-- | @'ParsecT' e s m a@ is a parser with custom data component of error
+-- @e@, stream type @s@, underlying monad @m@ and return type @a@.
+
+newtype ParsecT e s m a = ParsecT
+  { unParser
+      :: forall b. State s
+      -> (a -> State s   -> Hints (Token s) -> m b) -- consumed-OK
+      -> (ParseError s e -> State s         -> m b) -- consumed-error
+      -> (a -> State s   -> Hints (Token s) -> m b) -- empty-OK
+      -> (ParseError s e -> State s         -> m b) -- empty-error
+      -> m b }
+
+instance Functor (ParsecT e s m) where
+  fmap = pMap
+
+pMap :: (a -> b) -> ParsecT e s m a -> ParsecT e s m b
+pMap f p = ParsecT $ \s cok cerr eok eerr ->
+  unParser p s (cok . f) cerr (eok . f) eerr
+{-# INLINE pMap #-}
+
+-- | 'pure' returns a parser that __succeeds__ without consuming input.
+
+instance Stream s => Applicative (ParsecT e s m) where
+  pure     = pPure
+  (<*>)    = pAp
+  p1 *> p2 = p1 `pBind` const p2
+  p1 <* p2 = p1 `pBind` \x1 -> void p2 `pBind` \_ -> pure x1
+
+pPure :: a -> ParsecT e s m a
+pPure x = ParsecT $ \s _ _ eok _ -> eok x s mempty
+{-# INLINE pPure #-}
+
+pAp :: Stream s
+  => ParsecT e s m (a -> b)
+  -> ParsecT e s m a
+  -> ParsecT e s m b
+pAp m k = ParsecT $ \s cok cerr eok eerr ->
+  let mcok x s' hs = unParser k s' (cok . x) cerr
+        (accHints hs (cok . x)) (withHints hs cerr)
+      meok x s' hs = unParser k s' (cok . x) cerr
+        (accHints hs (eok . x)) (withHints hs eerr)
+  in unParser m s mcok cerr meok eerr
+{-# INLINE pAp #-}
+
+pBind :: Stream s
+  => ParsecT e s m a
+  -> (a -> ParsecT e s m b)
+  -> ParsecT e s m b
+pBind m k = ParsecT $ \s cok cerr eok eerr ->
+  let mcok x s' hs = unParser (k x) s' cok cerr
+        (accHints hs cok) (withHints hs cerr)
+      meok x s' hs = unParser (k x) s' cok cerr
+        (accHints hs eok) (withHints hs eerr)
+  in unParser m s mcok cerr meok eerr
+{-# INLINE pBind #-}
+
+pFail :: String -> ParsecT e s m a
+pFail msg = ParsecT $ \s@(State _ o _) _ _ _ eerr ->
+  let d = E.singleton (ErrorFail msg)
+  in eerr (FancyError o d) s
+{-# INLINE pFail #-}
+
+instance MonadTrans (ParsecT e s) where
+  lift amb = ParsecT $ \s _ _ eok _ ->
+    amb >>= \a -> eok a s mempty
+
+----------------------------------------------------------------------------
+-- Helper functions
+
+-- | Convert 'ParseError' record to 'Hints'.
+
+toHints
+  :: Stream s
+  => Int               -- ^ Current offset in input stream
+  -> ParseError s e    -- ^ Parse error to convert
+  -> Hints (Token s)
+toHints streamPos = \case
+  TrivialError errOffset _ ps ->
+    -- NOTE This is important to check here that the error indeed has
+    -- happened at the same position as current position of stream because
+    -- there might have been backtracking with 'try' and in that case we
+    -- must not convert such a parse error to hints.
+    if streamPos == errOffset
+      then Hints (if E.null ps then [] else [ps])
+      else mempty
+  FancyError _ _ -> mempty
+{-# INLINE toHints #-}
+
+-- | @'withHints' hs c@ makes “error” continuation @c@ use given hints @hs@.
+--
+-- Note that if resulting continuation gets 'ParseError' that has custom
+-- data in it, hints are ignored.
+
+withHints
+  :: Stream s
+  => Hints (Token s)   -- ^ Hints to use
+  -> (ParseError s e -> State s -> m b) -- ^ Continuation to influence
+  -> ParseError s e    -- ^ First argument of resulting continuation
+  -> State s           -- ^ Second argument of resulting continuation
+  -> m b
+withHints (Hints ps') c e =
+  case e of
+    TrivialError pos us ps -> c (TrivialError pos us (E.unions (ps : ps')))
+    _ -> c e
+{-# INLINE withHints #-}
+
+-- | @'accHints' hs c@ results in “OK” continuation that will add given
+-- hints @hs@ to third argument of original continuation @c@.
+
+accHints
+  :: Hints t           -- ^ 'Hints' to add
+  -> (a -> State s -> Hints t -> m b) -- ^ An “OK” continuation to alter
+  -> (a -> State s -> Hints t -> m b) -- ^ Altered “OK” continuation
+accHints hs1 c x s hs2 = c x s (hs1 <> hs2)
+{-# INLINE accHints #-}
+
+-- | Replace the most recent group of hints (if any) with the given
+-- 'ErrorItem' (or delete it if 'Nothing' is given). This is used in the
+-- 'label' primitive.
+
+refreshLastHint :: Hints t -> Maybe (ErrorItem t) -> Hints t
+refreshLastHint (Hints [])     _        = Hints []
+refreshLastHint (Hints (_:xs)) Nothing  = Hints xs
+refreshLastHint (Hints (_:xs)) (Just m) = Hints (E.singleton m : xs)
+{-# INLINE refreshLastHint #-}
+
+-- | Low-level unpacking of the 'ParsecT' type.
+
+runParsecT :: Monad m
+  => ParsecT e s m a -- ^ Parser to run
+  -> State s       -- ^ Initial state
+  -> m (Reply e s a)
+runParsecT p s = unParser p s cok cerr eok eerr
+  where
+    cok a s' _  = return $ Reply s' Consumed (OK a)
+    cerr err s' = return $ Reply s' Consumed (Error err)
+    eok a s' _  = return $ Reply s' Virgin   (OK a)
+    eerr err s' = return $ Reply s' Virgin   (Error err)
+
+-- | Transform any custom errors thrown by the parser using the given
+-- function. Similar in function and purpose to @withExceptT@.
+--
+-- @since 7.0.0
+
+withParsecT :: (Monad m, Ord e')
+  => (e -> e')
+  -> ParsecT e s m a
+  -> ParsecT e' s m a
+withParsecT f p =
+  ParsecT $ \s cok cerr eok eerr ->
+    unParser p s cok (cerr . mapParseError f) eok (eerr . mapParseError f)
+{-# INLINE withParsecT #-}

--- a/base-4-13-or-later/Text/Megaparsec/Internal/Monad.hs
+++ b/base-4-13-or-later/Text/Megaparsec/Internal/Monad.hs
@@ -1,0 +1,15 @@
+{-# OPTIONS_GHC -Wno-orphans            #-}
+module Text.Megaparsec.Internal.Monad() where
+
+import qualified Control.Monad.Fail  as Fail
+import Text.Megaparsec.Stream
+import Text.Megaparsec.Internal.ParsecT
+
+-- | 'return' returns a parser that __succeeds__ without consuming input.
+
+instance Stream s => Monad (ParsecT e s m) where
+  return = pure
+  (>>=)  = pBind
+
+instance Stream s => Fail.MonadFail (ParsecT e s m) where
+  fail = pFail

--- a/base-earlier-than-4-13/Text/Megaparsec/Internal/Monad.hs
+++ b/base-earlier-than-4-13/Text/Megaparsec/Internal/Monad.hs
@@ -1,0 +1,16 @@
+{-# OPTIONS_GHC -Wno-orphans            #-}
+module Text.Megaparsec.Internal.Monad() where
+
+import qualified Control.Monad.Fail  as Fail
+import Text.Megaparsec.Stream
+import Text.Megaparsec.Internal.ParsecT
+
+-- | 'return' returns a parser that __succeeds__ without consuming input.
+
+instance Stream s => Monad (ParsecT e s m) where
+  return = pure
+  (>>=)  = pBind
+  fail   = Fail.fail
+
+instance Stream s => Fail.MonadFail (ParsecT e s m) where
+  fail = pFail

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -32,9 +32,12 @@ flag dev
   manual:             True
   default:            False
 
+flag with-base-earlier-than-4-13
+  description:        build with base earlier than 4.13.
+  default:            False
+
 library
-  build-depends:      base         >= 4.11  && < 5.0
-                    , bytestring   >= 0.2   && < 0.11
+  build-depends:      bytestring   >= 0.2   && < 0.11
                     , case-insensitive >= 1.2 && < 1.3
                     , containers   >= 0.5   && < 0.7
                     , deepseq      >= 1.3   && < 1.5
@@ -52,6 +55,8 @@ library
                     , Text.Megaparsec.Error
                     , Text.Megaparsec.Error.Builder
                     , Text.Megaparsec.Internal
+                    , Text.Megaparsec.Internal.Monad
+                    , Text.Megaparsec.Internal.ParsecT
                     , Text.Megaparsec.Pos
                     , Text.Megaparsec.Stream
   other-modules:      Text.Megaparsec.Class
@@ -67,6 +72,12 @@ library
                       -Wincomplete-record-updates
                       -Wincomplete-uni-patterns
                       -Wnoncanonical-monad-instances
+  if flag(with-base-earlier-than-4-13)
+    build-depends: base >= 4.11 && < 4.13
+    hs-source-dirs:   . base-earlier-than-4-13
+  else
+    build-depends: base >= 4.13 && < 5.0
+    hs-source-dirs:   . base-4-13-or-later
   default-language:   Haskell2010
 
 benchmark bench-speed


### PR DESCRIPTION
This PR splits `Text.Megaparsec.Internal` in three modules. 
* `Text.Megaparsec.Internal`: A module containing definitions that use the `Monad` instance of `ParsecT`.
* `Text.Megaparsec.Internal.Monad`: A module providing the `Monad` instance of `ParsecT`.
* `Text.Megaparsec.Internal.ParsecT`: A module providing the definition of `ParsecT` and all the definitions that don't depend on its `Monad` instance.

In addition, there are two variants of `Text.Megaparsec.Internal.Monad`, one for base earlier than 4.13, and one variant for base-4.13 and later. cabal chooses between the two depending on which version of base is available.