### PR TITLE
Removes CPP from Text.Megaparsec.Internal (take 2)

### DIFF
--- a/Text/Megaparsec/Internal.hs
+++ b/Text/Megaparsec/Internal.hs
@@ -14,7 +14,6 @@
 --
 -- @since 6.5.0
 
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -38,7 +37,10 @@ module Text.Megaparsec.Internal
   , accHints
   , refreshLastHint
   , runParsecT
-  , withParsecT )
+  , withParsecT
+  , pBind
+  , pFail
+  )
 where
 
 import Control.Applicative
@@ -57,6 +59,7 @@ import Data.Set (Set)
 import Data.String (IsString (..))
 import Text.Megaparsec.Class
 import Text.Megaparsec.Error
+import Text.Megaparsec.Internal.Monad ()
 import Text.Megaparsec.State
 import Text.Megaparsec.Stream
 import qualified Control.Monad.Fail  as Fail
@@ -186,15 +189,6 @@ pAp m k = ParsecT $ \s cok cerr eok eerr ->
 instance (Ord e, Stream s) => Alternative (ParsecT e s m) where
   empty  = mzero
   (<|>)  = mplus
-
--- | 'return' returns a parser that __succeeds__ without consuming input.
-
-instance Stream s => Monad (ParsecT e s m) where
-  return = pure
-  (>>=)  = pBind
-#if !(MIN_VERSION_base(4,13,0))
-  fail   = Fail.fail
-#endif
 
 pBind :: Stream s
   => ParsecT e s m a

--- a/Text/Megaparsec/Internal.hs-boot
+++ b/Text/Megaparsec/Internal.hs-boot
@@ -1,0 +1,28 @@
+{-# LANGUAGE RankNTypes                 #-}
+module Text.Megaparsec.Internal where
+
+import Data.Set (Set)
+import Text.Megaparsec.Error
+import Text.Megaparsec.State
+import Text.Megaparsec.Stream
+
+newtype Hints t = Hints [Set (ErrorItem t)]
+
+instance Functor (ParsecT e s m)
+instance Stream s => Applicative (ParsecT e s m)
+
+newtype ParsecT e s m a = ParsecT
+  { unParser
+      :: forall b. State s
+      -> (a -> State s   -> Hints (Token s) -> m b) -- consumed-OK
+      -> (ParseError s e -> State s         -> m b) -- consumed-error
+      -> (a -> State s   -> Hints (Token s) -> m b) -- empty-OK
+      -> (ParseError s e -> State s         -> m b) -- empty-error
+      -> m b }
+
+pBind :: Stream s
+  => ParsecT e s m a
+  -> (a -> ParsecT e s m b)
+  -> ParsecT e s m b
+
+pFail :: String -> ParsecT e s m a

--- a/base-4-13-or-later/Text/Megaparsec/Internal/Monad.hs
+++ b/base-4-13-or-later/Text/Megaparsec/Internal/Monad.hs
@@ -1,0 +1,11 @@
+{-# OPTIONS_GHC -Wno-orphans            #-}
+module Text.Megaparsec.Internal.Monad() where
+
+import {-# SOURCE #-} Text.Megaparsec.Internal
+import Text.Megaparsec.Stream
+
+-- | 'return' returns a parser that __succeeds__ without consuming input.
+
+instance Stream s => Monad (ParsecT e s m) where
+  return = pure
+  (>>=)  = pBind

--- a/base-earlier-than-4-13/Text/Megaparsec/Internal/Monad.hs
+++ b/base-earlier-than-4-13/Text/Megaparsec/Internal/Monad.hs
@@ -1,0 +1,12 @@
+{-# OPTIONS_GHC -Wno-orphans            #-}
+module Text.Megaparsec.Internal.Monad() where
+
+import {-# SOURCE #-} Text.Megaparsec.Internal
+import Text.Megaparsec.Stream
+
+-- | 'return' returns a parser that __succeeds__ without consuming input.
+
+instance Stream s => Monad (ParsecT e s m) where
+  return = pure
+  (>>=)  = pBind
+  fail   = pFail

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -32,9 +32,12 @@ flag dev
   manual:             True
   default:            False
 
+flag with-base-earlier-than-4-13
+  description:        build with base earlier than 4.13.
+  default:            False
+
 library
-  build-depends:      base         >= 4.11  && < 5.0
-                    , bytestring   >= 0.2   && < 0.11
+  build-depends:      bytestring   >= 0.2   && < 0.11
                     , case-insensitive >= 1.2 && < 1.3
                     , containers   >= 0.5   && < 0.7
                     , deepseq      >= 1.3   && < 1.5
@@ -52,6 +55,7 @@ library
                     , Text.Megaparsec.Error
                     , Text.Megaparsec.Error.Builder
                     , Text.Megaparsec.Internal
+                    , Text.Megaparsec.Internal.Monad
                     , Text.Megaparsec.Pos
                     , Text.Megaparsec.Stream
   other-modules:      Text.Megaparsec.Class
@@ -67,6 +71,12 @@ library
                       -Wincomplete-record-updates
                       -Wincomplete-uni-patterns
                       -Wnoncanonical-monad-instances
+  if flag(with-base-earlier-than-4-13)
+    build-depends: base >= 4.11 && < 4.13
+    hs-source-dirs:   . base-earlier-than-4-13
+  else
+    build-depends: base >= 4.13 && < 5.0
+    hs-source-dirs:   . base-4-13-or-later
   default-language:   Haskell2010
 
 benchmark bench-speed


### PR DESCRIPTION
It splits Text.Megaparsec.Internal in two modules forming a cycle.

* Text.Megaparsec.Internal: mostly unchanged but without the Monad instance for ParsecT,
* Text.Megaparsec.Internal.Monad: containing the Monad instance for ParsecT.

In addition, there are two variants of Text.Megaparsec.Internal.Monad, one for base earlier than 4.13, and one variant for base-4.13 and later. cabal chooses between the two depending on which version of base is available.