### PR TITLE
Re-organize error reporting functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Megaparec 8.0.0
 
+* The methods `failure` and `fancyFailure` of `MonadParsec` are now ordinary
+  functions and live in `Text.Megaparsec`. They are defined in terms of the
+  new `parseError` method of `MonadParsec`. This method allows us to signal
+  parse errors at a given offset without manipulating parser state manually.
+
 * Added the `tokensLength` method to the `Stream` type class to improve
   support for custom input streams.
 

--- a/Text/Megaparsec/Internal.hs
+++ b/Text/Megaparsec/Internal.hs
@@ -304,8 +304,7 @@ instance MonadTrans (ParsecT e s) where
     amb >>= \a -> eok a s mempty
 
 instance (Ord e, Stream s) => MonadParsec e s (ParsecT e s m) where
-  failure           = pFailure
-  fancyFailure      = pFancyFailure
+  parseError        = pParseError
   label             = pLabel
   try               = pTry
   lookAhead         = pLookAhead
@@ -321,20 +320,11 @@ instance (Ord e, Stream s) => MonadParsec e s (ParsecT e s m) where
   getParserState    = pGetParserState
   updateParserState = pUpdateParserState
 
-pFailure
-  :: Maybe (ErrorItem (Token s))
-  -> Set (ErrorItem (Token s))
+pParseError
+  :: ParseError s e
   -> ParsecT e s m a
-pFailure us ps = ParsecT $ \s@(State _ o _) _ _ _ eerr ->
-  eerr (TrivialError o us ps) s
-{-# INLINE pFailure #-}
-
-pFancyFailure
-  :: Set (ErrorFancy e)
-  -> ParsecT e s m a
-pFancyFailure xs = ParsecT $ \s@(State _ o _) _ _ _ eerr ->
-  eerr (FancyError o xs) s
-{-# INLINE pFancyFailure #-}
+pParseError e = ParsecT $ \s _ _ _ eerr -> eerr e s
+{-# INLINE pParseError #-}
 
 pLabel :: String -> ParsecT e s m a -> ParsecT e s m a
 pLabel l p = ParsecT $ \s cok cerr eok eerr ->

--- a/default.nix
+++ b/default.nix
@@ -98,7 +98,6 @@ in {
       cachix
       cassava-megaparsec
       cue-sheet
-      dhall
       hledger
       hnix
       language-puppet
@@ -107,6 +106,7 @@ in {
       replace-megaparsec
       stache
       tomland;
+    dhall = patch haskellPackages.dhall ./nix/patches/dhall.patch;
     idris = patch haskellPackages.idris ./nix/patches/idris.patch;
   };
 

--- a/megaparsec-tests/tests/Text/MegaparsecSpec.hs
+++ b/megaparsec-tests/tests/Text/MegaparsecSpec.hs
@@ -408,19 +408,7 @@ spec = do
 
   describe "primitive combinators" $ do
 
-    describe "failure" $
-      it "signals correct parse error" $
-        property $ \us ps -> do
-          let p :: MonadParsec Void String m => m ()
-              p = void (failure us ps)
-          grs p "" (`shouldFailWith` TrivialError 0 us ps)
-
-    describe "fancyFailure" $
-      it "singals correct parse error" $
-        property $ \xs -> do
-          let p :: MonadParsec Void String m => m ()
-              p = void (fancyFailure xs)
-          grs p "" (`shouldFailWith` FancyError 0 xs)
+    -- NOTE 'parseError' is tested via 'failure' and 'fancyFailure'.
 
     describe "label" $ do
       context "when inner parser succeeds consuming input" $ do
@@ -1130,6 +1118,20 @@ spec = do
 
     -- NOTE 'chunk' is tested via 'string' in "Text.Megaparsec.Char" and
     -- "Text.Megaparsec.Byte".
+
+    describe "failure" $
+      it "signals correct parse error" $
+        property $ \us ps -> do
+          let p :: MonadParsec Void String m => m ()
+              p = void (failure us ps)
+          grs p "" (`shouldFailWith` TrivialError 0 us ps)
+
+    describe "fancyFailure" $
+      it "singals correct parse error" $
+        property $ \xs -> do
+          let p :: MonadParsec Void String m => m ()
+              p = void (fancyFailure xs)
+          grs p "" (`shouldFailWith` FancyError 0 xs)
 
     describe "unexpected" $
       it "signals correct parse error" $

--- a/nix/patches/dhall.patch
+++ b/nix/patches/dhall.patch
@@ -1,0 +1,15 @@
+diff --git a/dhall/src/Dhall/Parser/Combinators.hs b/dhall/src/Dhall/Parser/Combinators.hs
+index 2ad0f243..522a9883 100644
+--- a/src/Dhall/Parser/Combinators.hs
++++ b/src/Dhall/Parser/Combinators.hs
+@@ -128,9 +128,7 @@ instance MonadPlus Parser where
+     -- {-# INLINE mplus #-}
+ 
+ instance Text.Megaparsec.MonadParsec Void Text Parser where
+-    failure u e    = Parser (Text.Megaparsec.failure u e)
+-
+-    fancyFailure e = Parser (Text.Megaparsec.fancyFailure e)
++    parseError e = Parser (Text.Megaparsec.parseError e)
+ 
+     label l (Parser p) = Parser (Text.Megaparsec.label l p)
+ 


### PR DESCRIPTION
Close #381.

The methods `failure` and `fancyFailure` of `MonadParsec` are now ordinary functions and live in `Text.Megaparsec`. They are defined in terms of the new `parseError` method of `MonadParsec`. This method allows us to signal parse errors at a given offset without manipulating parser state manually.

TODO:

- [x] Adjust the tests.