### PR TITLE
Allow registration of delayed parse errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,16 @@ install:
   - travis_retry cabal new-update
 
 script:
-  - cabal new-build all --enable-tests --enable-benchmarks --flags=dev
-  - cabal new-test all --enable-tests --enable-benchmarks --flags=dev
+  # FIXME The recent changes are breaking and we need to release newer
+  # versions of hspec-megaparsec to make the tests work. I'll restore CI
+  # right after release of Megaparsec 8. For now we just test that it builds
+  # on CI and locally using Nix.
+  - cabal new-build megaparsec --enable-tests --enable-benchmarks --flags=dev
+  # - cabal new-test all --enable-tests --enable-benchmarks --flags=dev
   - cabal new-haddock megaparsec
-  - cabal new-haddock megaparsec-tests
+  # - cabal new-haddock megaparsec-tests
   - cabal new-sdist
-  - cd megaparsec-tests && cabal new-sdist
+  # - cd megaparsec-tests && cabal new-sdist
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,20 @@
   new `parseError` method of `MonadParsec`. This method allows us to signal
   parse errors at a given offset without manipulating parser state manually.
 
+* Megaparsec now supports registration of “delayed” parse errors. On lower
+  level we added a new field called `stateParseErrors` to the `State`
+  record. The type also had to change from `State s` to `State s e`. This
+  field contains the list of registered `ParseErrors` that do not end
+  parsing immediately but still will cause failure in the end if the list is
+  not empty. Users are expected to register parse errors using the three
+  functions: `registerParseError`, `registerFailure`, and
+  `registerFancyFailure`. These functions are analogous to those without the
+  `register` prefix, except that they have “delayed” effect.
+
 * Added the `tokensLength` method to the `Stream` type class to improve
   support for custom input streams.
+
+* Added the `setErrorOffset` function to set offset of `ParseError`s.
 
 * Changed type signatures of `reachOffset` and `reachOffsetNoLine` methods
   of the `Stream` type class. Instead of three-tuple `reachOffset` now

--- a/Text/Megaparsec/Class.hs
+++ b/Text/Megaparsec/Class.hs
@@ -265,11 +265,11 @@ class (Stream s, MonadPlus m) => MonadParsec e s m | m -> e s where
 
   -- | Return the full parser state as a 'State' record.
 
-  getParserState :: m (State s)
+  getParserState :: m (State s e)
 
   -- | @'updateParserState' f@ applies the function @f@ to the parser state.
 
-  updateParserState :: (State s -> State s) -> m ()
+  updateParserState :: (State s e -> State s e) -> m ()
 
 ----------------------------------------------------------------------------
 -- Lifting through MTL

--- a/Text/Megaparsec/Debug.hs
+++ b/Text/Megaparsec/Debug.hs
@@ -125,8 +125,8 @@ showStream pxy ts =
 -- after parsing.
 
 streamDelta
-  :: State s           -- ^ State of parser before consumption
-  -> State s           -- ^ State of parser after consumption
+  :: State s e         -- ^ State of parser before consumption
+  -> State s e         -- ^ State of parser after consumption
   -> Int               -- ^ Number of consumed tokens
 streamDelta s0 s1 = stateOffset s1 - stateOffset s0
 

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -15,17 +15,17 @@
 -- You probably do not want to import this module directly because
 -- "Text.Megaparsec" re-exports it anyway.
 
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE DeriveDataTypeable  #-}
-{-# LANGUAGE DeriveFunctor       #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-{-# LANGUAGE UndecidableInstances#-}
+{-# LANGUAGE BangPatterns         #-}
+{-# LANGUAGE DeriveDataTypeable   #-}
+{-# LANGUAGE DeriveFunctor        #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Text.Megaparsec.Error
   ( -- * Parse error type
@@ -34,6 +34,7 @@ module Text.Megaparsec.Error
   , ParseError (..)
   , mapParseError
   , errorOffset
+  , setErrorOffset
   , ParseErrorBundle (..)
   , attachSourcePos
     -- * Pretty-printing
@@ -173,13 +174,21 @@ mapParseError :: Ord e'
 mapParseError _ (TrivialError o u p) = TrivialError o u p
 mapParseError f (FancyError o x) = FancyError o (E.map (fmap f) x)
 
--- | Get offset of given 'ParseError'.
+-- | Get offset of 'ParseError'.
 --
 -- @since 7.0.0
 
 errorOffset :: ParseError s e -> Int
 errorOffset (TrivialError o _ _) = o
 errorOffset (FancyError   o _)   = o
+
+-- | Set offset of 'ParseError'.
+--
+-- @since 8.0.0
+
+setErrorOffset :: Int -> ParseError s e -> ParseError s e
+setErrorOffset o (TrivialError _ u p) = TrivialError o u p
+setErrorOffset o (FancyError _ x) = FancyError o x
 
 -- | Merge two error data structures into one joining their collections of
 -- message items and preferring the longest match. In other words, earlier

--- a/Text/Megaparsec/Error.hs-boot
+++ b/Text/Megaparsec/Error.hs-boot
@@ -1,0 +1,10 @@
+{-# LANGUAGE RoleAnnotations #-}
+
+module Text.Megaparsec.Error
+  ( ParseError
+  )
+where
+
+type role ParseError nominal nominal
+
+data ParseError s e

--- a/default.nix
+++ b/default.nix
@@ -57,14 +57,20 @@ let
     # normally fails. We want to build it and run the tests anyway, so we
     # have to do these manipulations.
     "parser-combinators-tests" = pkgs.haskell.lib.dontHaddock
-      (super.parser-combinators-tests.overrideAttrs (drv: {
-        installPhase = "mkdir $out";
-        broken = false;
-      }));
+      (patch
+        (super.parser-combinators-tests.overrideAttrs (drv: {
+          installPhase = "mkdir $out";
+          broken = false;
+        }))
+        ./nix/patches/parser-combinators-tests.patch);
     "modern-uri" = doBenchmark super.modern-uri;
-    "mmark" = doBenchmark super.mmark;
+    "mmark" = doBenchmark (patch super.mmark ./nix/patches/mmark.patch);
     "parsers-bench" = doBenchmark
       (super.callCabal2nix "parsers-bench" parsersBenchSource { });
+    "hspec-megaparsec" = patch super.hspec-megaparsec ./nix/patches/hspec-megaparsec.patch;
+    "dhall" = patch super.dhall ./nix/patches/dhall.patch;
+    "idris" = patch super.idris ./nix/patches/idris.patch;
+    "hledger-lib" = patch super.hledger-lib ./nix/patches/hledger-lib.patch;
   };
 
   updatedPkgs = pkgs // {
@@ -98,16 +104,16 @@ in {
       cachix
       cassava-megaparsec
       cue-sheet
+      dhall
       hledger
       hnix
+      idris
       language-puppet
       mmark
       modern-uri
       replace-megaparsec
       stache
       tomland;
-    dhall = patch haskellPackages.dhall ./nix/patches/dhall.patch;
-    idris = patch haskellPackages.idris ./nix/patches/idris.patch;
   };
 
   # Benchmarks:

--- a/megaparsec-tests/src/Test/Hspec/Megaparsec/AdHoc.hs
+++ b/megaparsec-tests/src/Test/Hspec/Megaparsec/AdHoc.hs
@@ -97,7 +97,7 @@ prs'
      -- ^ Parser to run
   -> String
      -- ^ Input for the parser
-  -> (State String, Either (ParseErrorBundle String Void) a)
+  -> (State String Void, Either (ParseErrorBundle String Void) a)
      -- ^ Result of parsing
 prs' p s = runParser' p (initialState s)
 
@@ -140,7 +140,7 @@ grs p s r = do
 grs'
   :: (forall m. MonadParsec Void String m => m a) -- ^ Parser to run
   -> String            -- ^ Input for the parser
-  -> ((State String, Either (ParseErrorBundle String Void) a) -> Expectation)
+  -> ((State String Void, Either (ParseErrorBundle String Void) a) -> Expectation)
     -- ^ How to check result of parsing
   -> Expectation
 grs' p s r = do
@@ -297,7 +297,7 @@ instance (Arbitrary (Token s), Ord (Token s), Arbitrary e, Ord e)
       <$> (getNonNegative <$> arbitrary)
       <*> (E.fromList <$> scaleDown arbitrary) ]
 
-instance Arbitrary s => Arbitrary (State s) where
+instance Arbitrary s => Arbitrary (State s e) where
   arbitrary = do
     input  <- scaleDown arbitrary
     offset <- choose (1, 10000)
@@ -309,6 +309,7 @@ instance Arbitrary s => Arbitrary (State s) where
         { pstateInput = input
         , pstateOffset = offset
         }
+      , stateParseErrors = []
       }
 
 instance Arbitrary s => Arbitrary (PosState s) where

--- a/megaparsec-tests/tests/Text/Megaparsec/Byte/LexerSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/Byte/LexerSpec.hs
@@ -301,7 +301,7 @@ prs'
      -- ^ Parser to run
   -> ByteString
      -- ^ Input for the parser
-  -> (State ByteString, Either (ParseErrorBundle ByteString Void) a)
+  -> (State ByteString Void, Either (ParseErrorBundle ByteString Void) a)
      -- ^ Result of parsing
 prs' p s = runParser' p (initialState s)
 

--- a/megaparsec-tests/tests/Text/Megaparsec/ByteSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/ByteSpec.hs
@@ -213,7 +213,7 @@ prs'
      -- ^ Parser to run
   -> ByteString
      -- ^ Input for the parser
-  -> (State ByteString, Either (ParseErrorBundle ByteString Void) a)
+  -> (State ByteString Void, Either (ParseErrorBundle ByteString Void) a)
      -- ^ Result of parsing
 prs' p s = runParser' p (initialState s)
 

--- a/megaparsec-tests/tests/Text/Megaparsec/ErrorSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/ErrorSpec.hs
@@ -66,13 +66,7 @@ spec = do
           TrivialError pos us ps <> FancyError pos xs `shouldBe`
             (FancyError pos xs :: PE)
 
-  describe "errorOffset" $
-    it "returns error position" $
-      property $ \e ->
-        errorOffset e `shouldBe`
-          (case e :: PE of
-            TrivialError o _ _ -> o
-            FancyError   o _   -> o)
+  -- NOTE 'errorOffset' and 'setErrorOffset' are trivial.
 
   describe "attachSourcePos" $
     it "attaches the positions correctly" $

--- a/nix/patches/dhall.patch
+++ b/nix/patches/dhall.patch
@@ -13,3 +13,18 @@ index 2ad0f243..522a9883 100644
  
      label l (Parser p) = Parser (Text.Megaparsec.label l p)
  
+diff --git a/dhall/src/Dhall/Parser/Expression.hs b/dhall/src/Dhall/Parser/Expression.hs
+index 0162b728..76c00ad4 100644
+--- a/src/Dhall/Parser/Expression.hs
++++ b/src/Dhall/Parser/Expression.hs
+@@ -57,8 +57,8 @@ getOffset = Text.Megaparsec.stateTokensProcessed <$> Text.Megaparsec.getParserSt
+ 
+ setOffset :: Text.Megaparsec.MonadParsec e s m => Int -> m ()
+ #if MIN_VERSION_megaparsec(7, 0, 0)
+-setOffset o = Text.Megaparsec.updateParserState $ \(Text.Megaparsec.State s _ pst) ->
+-  Text.Megaparsec.State s o pst
++setOffset o = Text.Megaparsec.updateParserState $ \(Text.Megaparsec.State s _ pst de) ->
++  Text.Megaparsec.State s o pst de
+ #else
+ setOffset o = Text.Megaparsec.updateParserState $ \(Text.Megaparsec.State s p _ stw) ->
+   Text.Megaparsec.State s p o stw

--- a/nix/patches/hledger-lib.patch
+++ b/nix/patches/hledger-lib.patch
@@ -1,0 +1,21 @@
+diff --git a/hledger-lib/Text/Megaparsec/Custom.hs b/hledger-lib/Text/Megaparsec/Custom.hs
+index 0d217f2f..f5ef950a 100644
+--- a/Text/Megaparsec/Custom.hs
++++ b/Text/Megaparsec/Custom.hs
+@@ -176,7 +172,7 @@ reparseExcerpt (SourceExcerpt offset txt) p = do
+     Left errBundle -> customFailure $ ErrorReparsing $ bundleErrors errBundle
+ 
+   where
+-    offsetInitialState :: Int -> s -> State s
++    offsetInitialState :: Int -> s -> State s e
+     offsetInitialState initialOffset s = State
+       { stateInput  = s
+       , stateOffset = initialOffset
+@@ -187,6 +183,7 @@ reparseExcerpt (SourceExcerpt offset txt) p = do
+         , pstateTabWidth = defaultTabWidth
+         , pstateLinePrefix = ""
+         }
++      , stateParseErrors = []
+       }
+ 
+ --- * Pretty-printing custom parse errors

--- a/nix/patches/hspec-megaparsec.patch
+++ b/nix/patches/hspec-megaparsec.patch
@@ -1,0 +1,36 @@
+diff --git a/Test/Hspec/Megaparsec.hs b/Test/Hspec/Megaparsec.hs
+index 2645b3c..e639426 100644
+--- a/Test/Hspec/Megaparsec.hs
++++ b/Test/Hspec/Megaparsec.hs
+@@ -184,7 +184,7 @@ failsLeaving
+      , Eq s
+      , Show s
+      )
+-  => (State s, Either (ParseErrorBundle s e) a)
++  => (State s e, Either (ParseErrorBundle s e) a)
+      -- ^ Parser that takes stream and produces result along with actual
+      -- state information
+   -> s                 -- ^ Part of input that should be left unconsumed
+@@ -210,7 +210,7 @@ succeedsLeaving
+      , ShowErrorComponent e
+      , Stream s
+      )
+-  => (State s, Either (ParseErrorBundle s e) a)
++  => (State s e, Either (ParseErrorBundle s e) a)
+      -- ^ Parser that takes stream and produces result along with actual
+      -- state information
+   -> s                 -- ^ Part of input that should be left unconsumed
+@@ -221,11 +221,12 @@ succeedsLeaving
+ 
+ -- | Given input for parsing, construct initial state for parser.
+ 
+-initialState :: s -> State s
++initialState :: s -> State s e
+ initialState s = State
+   { stateInput  = s
+   , stateOffset = 0
+   , statePosState = initialPosState s
++  , stateParseErrors = []
+   }
+ 
+ -- | Given input for parsing, construct initial positional state.

--- a/nix/patches/idris.patch
+++ b/nix/patches/idris.patch
@@ -1,5 +1,5 @@
 diff --git a/src/Idris/Parser/Stack.hs b/src/Idris/Parser/Stack.hs
-index f75789ab6..9e598024e 100644
+index f75789ab6..fb7845203 100644
 --- a/src/Idris/Parser/Stack.hs
 +++ b/src/Idris/Parser/Stack.hs
 @@ -76,11 +76,11 @@ parseErrorOffset = P.errorOffset . parseError
@@ -16,3 +16,12 @@ index f75789ab6..9e598024e 100644
  
  -- | A fully formatted parse error, with caret and bar, etc.
  prettyError :: ParseError -> String
+@@ -88,7 +88,7 @@ prettyError =  P.errorBundlePretty . unParseError
+ 
+ {- * Mark and restore -}
+ 
+-type Mark = P.State String
++type Mark = P.State String Void
+ 
+ -- | Retrieve the parser state so we can restart from this point later.
+ mark :: Parsing m => m Mark

--- a/nix/patches/mmark.patch
+++ b/nix/patches/mmark.patch
@@ -1,0 +1,125 @@
+diff --git a/Text/MMark/Parser.hs b/Text/MMark/Parser.hs
+index 6e03730..83bafee 100644
+--- a/Text/MMark/Parser.hs
++++ b/Text/MMark/Parser.hs
+@@ -439,9 +439,8 @@ pReferenceDef = do
+       (Just True,  Nothing) -> return ()
+       _                     -> hidden eof <|> eol
+     conflict <- registerReference dlabel (uri, mtitle)
+-    when conflict $ do
+-      setOffset o
+-      customFailure (DuplicateReferenceDefinition dlabel)
++    when conflict $
++      customFailure' o (DuplicateReferenceDefinition dlabel)
+     Nothing <$ sc
+   where
+     recover err =
+@@ -782,20 +781,15 @@ pLocation innerOffset inner = do
+     withRef =
+       pRefLabel >>= uncurry lookupRef
+     collapsed o inlines = do
+-      -- NOTE We need to do these manipulations so the failure caused by
+-      -- @'string' "[]"@ does not overwrite our custom failures.
+-      o' <- getOffset
+-      setOffset o
+-      (void . hidden . string) "[]"
+-      setOffset (o' + 2)
++      region (setErrorOffset o) $
++        (void . hidden . string) "[]"
+       lookupRef o (mkLabel inlines)
+     shortcut o inlines =
+       lookupRef o (mkLabel inlines)
+     lookupRef o dlabel =
+       lookupReference dlabel >>= \case
+-        Left names -> do
+-          setOffset o
+-          customFailure (CouldNotFindReferenceDefinition dlabel names)
++        Left names ->
++          customFailure' o (CouldNotFindReferenceDefinition dlabel names)
+         Right x ->
+           return x
+     mkLabel = T.unwords . T.words . asPlainText
+@@ -863,9 +857,8 @@ pLfdr = try $ do
+     , r (SingleFrame SubscriptFrame)
+     , r (SingleFrame SuperscriptFrame) ]
+   let dels = inlineStateDel st
+-      failNow = do
+-        setOffset o
+-        (customFailure . NonFlankingDelimiterRun . toNesTokens) dels
++      failNow =
++        customFailure' o (NonFlankingDelimiterRun (toNesTokens dels))
+   lch <- getLastChar
+   rch <- getNextChar OtherChar
+   when (lch >= rch) failNow
+@@ -882,9 +875,8 @@ pRfdr frame = try $ do
+         other -> other
+   o <- getOffset
+   (void . expectingInlineContent . string) dels
+-  let failNow = do
+-        setOffset o
+-        (customFailure . NonFlankingDelimiterRun . toNesTokens) dels
++  let failNow =
++        customFailure' o (NonFlankingDelimiterRun (toNesTokens dels))
+   lch <- getLastChar
+   rch <- getNextChar SpaceChar
+   when (lch <= rch) failNow
+@@ -974,9 +966,8 @@ entityRef = do
+   name <- try . region f $ between (char '&') (char ';')
+     (takeWhile1P Nothing Char.isAlphaNum <?> "HTML5 entity name")
+   case HM.lookup name htmlEntityMap of
+-    Nothing -> do
+-      setOffset o
+-      customFailure (UnknownHtmlEntityName name)
++    Nothing ->
++      customFailure' o (UnknownHtmlEntityName name)
+     Just txt -> return (T.unpack txt)
+ 
+ -- | Parse a numeric character using the given numeric parser.
+@@ -987,9 +978,7 @@ numRef = do
+   let f = between (string "&#") (char ';')
+   n   <- try (f (char' 'x' *> L.hexadecimal)) <|> f L.decimal
+   if n == 0 || n > fromEnum (maxBound :: Char)
+-    then do
+-      setOffset o
+-      customFailure (InvalidNumericCharacter n)
++    then customFailure' o (InvalidNumericCharacter n)
+     else return (Char.chr n)
+ 
+ sc :: MonadParsec e Text m => m ()
+@@ -1248,3 +1237,15 @@ fromRight _         =
+ 
+ bakeText :: (String -> String) -> Text
+ bakeText = T.pack . reverse . ($ [])
++
++-- | Report custom failure at specified location.
++
++customFailure'
++  :: MonadParsec MMarkErr Text m
++  => Int
++  -> MMarkErr
++  -> m a
++customFailure' o e =
++  parseError $ FancyError
++    o
++    (E.singleton (ErrorCustom e))
+diff --git a/Text/MMark/Parser/Internal.hs b/Text/MMark/Parser/Internal.hs
+index abe8aaa..bb3dc12 100644
+--- a/Text/MMark/Parser/Internal.hs
++++ b/Text/MMark/Parser/Internal.hs
+@@ -239,7 +239,7 @@ mkInitialState
+   :: FilePath          -- ^ File name to use
+   -> Text              -- ^ Input
+   -> Int               -- ^ Starting offset
+-  -> M.State Text
++  -> M.State Text e
+ mkInitialState file input offset = M.State
+   { stateInput = input
+   , stateOffset = offset
+@@ -250,6 +250,7 @@ mkInitialState file input offset = M.State
+     , pstateTabWidth = mkPos 4
+     , pstateLinePrefix = ""
+     }
++  , stateParseErrors = []
+   }
+ 
+ -- | Locally change state in a state monad and then restore it back.

--- a/nix/patches/parser-combinators-tests.patch
+++ b/nix/patches/parser-combinators-tests.patch
@@ -1,0 +1,13 @@
+diff --git a/parser-combinators-tests/tests/Control/Applicative/PermutationsSpec.hs b/parser-combinators-tests/tests/Control/Applicative/PermutationsSpec.hs
+index 96ed432..82216f8 100644
+--- a/tests/Control/Applicative/PermutationsSpec.hs
++++ b/tests/Control/Applicative/PermutationsSpec.hs
+@@ -91,7 +91,7 @@ prsp p = prs (runPermutation p)
+ prsp'
+   :: Permutation Parser a
+   -> String
+-  -> (State String, Either (ParseErrorBundle String Void) a)
++  -> (State String Void, Either (ParseErrorBundle String Void) a)
+ prsp' p = prs' (runPermutation p)
+ 
+ testPermParser :: Permutation Parser String


### PR DESCRIPTION
Close #359.

Megaparsec now supports registration of “delayed” parse errors. On lower level we added a new field called `stateParseErrors` to the `State` record. The type also had to change from `State s` to `State s e`. This field contains the list of registered `ParseErrors` that do not end parsing immediately but still will cause failure in the end if the list is not empty. Users are expected to register parse errors using the three functions: `registerParseError`, `registerFailure`, and `registerFancyFailure`. These functions are analogous to those without the `register` prefix, except that they have “delayed” effect.

TODO:

- [x] Running functions should fail if the list of delayed errors is not empty and the errors should be added to the parse error bundles.
- [x] Check effect on dependent packages.
- [x] Check how it affects performance if at all.
- [x] Clean up and make sure the Haddocks and other little details are correct.
- [x] Adjust/write tests.
- [x] Make all `deps` targets build. (I think only Idris remains now.)