### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Megaparec 8.0.0
+## Megaparsec 8.0.0
 
 * The methods `failure` and `fancyFailure` of `MonadParsec` are now ordinary
   functions and live in `Text.Megaparsec`. They are defined in terms of the
@@ -308,7 +308,7 @@
   `Text.Megaparsec.Byte` if you intend to parse binary data, then add
   qualified modules you need (permutation parsing, lexing, expression
   parsing, etc.). `Text.Megaparsec.Lexer` was renamed to
-  `Text.Megaparec.Char.Lexer` because many functions in it has the `Token s
+  `Text.Megaparsec.Char.Lexer` because many functions in it has the `Token s
   ~ Char` constraint. There is also `Text.Megaparsec.Byte.Lexer` now,
   although it has fewer functions.
 
@@ -401,17 +401,17 @@
 
 * Added `notChar` in `Text.Megaparsec.Char`.
 
-* Added `space1` in `Text.Megaprasec.Char`. This parser is like `space` but
+* Added `space1` in `Text.Megaparsec.Char`. This parser is like `space` but
   requires at least one space character to be present to succeed.
 
 * Added new module `Text.Megaparsec.Byte`, which is similar to
   `Text.Megaparsec.Char`, but for token streams of the type `Word8` instead
   of `Char`.
 
-* `integer` was dropped from `Text.Megaparec.Char.Lexer`. Use `decimal`
+* `integer` was dropped from `Text.Megaparsec.Char.Lexer`. Use `decimal`
   instead.
 
-* `number` was dropped from `Text.Megaparec.Char.Lexer`. Use `scientific`
+* `number` was dropped from `Text.Megaparsec.Char.Lexer`. Use `scientific`
   instead.
 
 * `decimal`, `octal`, and `hexadecimal` are now polymorphic in their return
@@ -823,7 +823,7 @@
 ### Built-in combinators
 
 * All built-in combinators in `Text.Megaparsec.Combinator` now work with any
-  instance of `Alternative` (some of them even with `Applicaitve`).
+  instance of `Alternative` (some of them even with `Applicative`).
 
 * Added more powerful `count'` parser. This parser can be told to parse from
   `m` to `n` occurrences of some thing. `count` is defined in terms of

--- a/HACKING.md
+++ b/HACKING.md
@@ -110,7 +110,7 @@ This will create several `result-*` symlinks with benchmarks. It is also
 possible to build benchmarks for just a specific package:
 
 ```console
-$ nix-bulid -A benches.megaparsec # builds megaparsec's microbenchmarks
+$ nix-build -A benches.megaparsec # builds megaparsec's microbenchmarks
 ```
 
 `cd` to `result/bench` and run benchmarks from there because some benchmarks

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ JSON (Megaparsec) |       25.45 μs |   203,824 |         9,176
 You can run the benchmarks yourself by executing:
 
 ```
-$ nix-bulid -A benches.parsers-bench
+$ nix-build -A benches.parsers-bench
 $ cd result/bench
 $ ./bench-memory
 $ ./bench-speed


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.