### PR TITLE
Remove the tests for ‘alphaNumChar’

### DIFF
--- a/megaparsec-tests/tests/Text/Megaparsec/ByteSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/ByteSpec.hs
@@ -114,9 +114,6 @@ spec = do
   describe "spaceChar" $
     checkCharRange "white space" [9, 10, 11, 12, 13, 32, 160] spaceChar
 
-  describe "alphaNumChar" $
-    checkCharPred "alphanumeric character" (isAlphaNum . toChar) alphaNumChar
-
   describe "printChar" $
     checkCharPred "printable character" (isPrint . toChar) printChar
 

--- a/megaparsec-tests/tests/Text/Megaparsec/CharSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/CharSpec.hs
@@ -120,9 +120,6 @@ spec = do
   describe "letterChar" $
     checkCharPred "letter" isAlpha letterChar
 
-  describe "alphaNumChar" $
-    checkCharPred "alphanumeric character" isAlphaNum alphaNumChar
-
   describe "printChar" $
     checkCharPred "printable character" isPrint printChar
 


### PR DESCRIPTION
Alphanumeric characters are not generated often enough so QuickCheck may
sometimes give up on this one. The function is defined analogous to other
similar functions so there is really no point in testing it.