### PR TITLE
Add ‘hspace’ and ‘hspace1’ functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Megaparsec 8.1.0
+
+* Added the functions `hspace` and `hspace1` to the `Text.Megaparsec.Char`
+  and `Text.Megaparsec.Byte` modules.
+
 ## Megaparsec 8.0.0
 
 * The methods `failure` and `fancyFailure` of `MonadParsec` are now ordinary

--- a/Text/Megaparsec/Byte.hs
+++ b/Text/Megaparsec/Byte.hs
@@ -20,7 +20,9 @@ module Text.Megaparsec.Byte
     eol,
     tab,
     space,
+    hspace,
     space1,
+    hspace1,
 
     -- * Categories of characters
     controlChar,
@@ -47,7 +49,7 @@ module Text.Megaparsec.Byte
 where
 
 import Control.Applicative
-import Data.Char hiding (toLower, toUpper)
+import Data.Char hiding (isSpace, toLower, toUpper)
 import Data.Functor (void)
 import Data.Proxy
 import Data.Word (Word8)
@@ -86,15 +88,29 @@ tab = char 9
 --
 -- See also: 'skipMany' and 'spaceChar'.
 space :: (MonadParsec e s m, Token s ~ Word8) => m ()
-space = void $ takeWhileP (Just "white space") isSpace'
+space = void $ takeWhileP (Just "white space") isSpace
 {-# INLINE space #-}
+
+-- | Like 'space', but does not accept newlines and carriage returns.
+--
+-- @since 8.1.0
+hspace :: (MonadParsec e s m, Token s ~ Word8) => m ()
+hspace = void $ takeWhileP (Just "white space") isHSpace
+{-# INLINE hspace #-}
 
 -- | Skip /one/ or more white space characters.
 --
 -- See also: 'skipSome' and 'spaceChar'.
 space1 :: (MonadParsec e s m, Token s ~ Word8) => m ()
-space1 = void $ takeWhile1P (Just "white space") isSpace'
+space1 = void $ takeWhile1P (Just "white space") isSpace
 {-# INLINE space1 #-}
+
+-- | Like 'space1', but does not accept newlines and carriage returns.
+--
+-- @since 8.1.0
+hspace1 :: (MonadParsec e s m, Token s ~ Word8) => m ()
+hspace1 = void $ takeWhile1P (Just "white space") isHSpace
+{-# INLINE hspace1 #-}
 
 ----------------------------------------------------------------------------
 -- Categories of characters
@@ -107,7 +123,7 @@ controlChar = satisfy (isControl . toChar) <?> "control character"
 -- | Parse a space character, and the control characters: tab, newline,
 -- carriage return, form feed, and vertical tab.
 spaceChar :: (MonadParsec e s m, Token s ~ Word8) => m (Token s)
-spaceChar = satisfy isSpace' <?> "white space"
+spaceChar = satisfy isSpace <?> "white space"
 {-# INLINE spaceChar #-}
 
 -- | Parse an upper-case character.
@@ -201,14 +217,25 @@ char' c =
 ----------------------------------------------------------------------------
 -- Helpers
 
--- | 'Word8'-specialized version of 'isSpace'.
-isSpace' :: Word8 -> Bool
-isSpace' x
+-- | 'Word8'-specialized version of 'Data.Char.isSpace'.
+isSpace :: Word8 -> Bool
+isSpace x
   | x >= 9 && x <= 13 = True
   | x == 32 = True
   | x == 160 = True
   | otherwise = False
-{-# INLINE isSpace' #-}
+{-# INLINE isSpace #-}
+
+-- | Like 'isSpace', but does not accept newlines and carriage returns.
+isHSpace :: Word8 -> Bool
+isHSpace x
+  | x == 9 = True
+  | x == 11 = True
+  | x == 12 = True
+  | x == 32 = True
+  | x == 160 = True
+  | otherwise = False
+{-# INLINE isHSpace #-}
 
 -- | Convert a byte to char.
 toChar :: Word8 -> Char

--- a/Text/Megaparsec/Char.hs
+++ b/Text/Megaparsec/Char.hs
@@ -22,7 +22,9 @@ module Text.Megaparsec.Char
     eol,
     tab,
     space,
+    hspace,
     space1,
+    hspace1,
 
     -- * Categories of characters
     controlChar,
@@ -98,6 +100,13 @@ space :: (MonadParsec e s m, Token s ~ Char) => m ()
 space = void $ takeWhileP (Just "white space") isSpace
 {-# INLINE space #-}
 
+-- | Like 'space', but does not accept newlines and carriage returns.
+--
+-- @since 8.1.0
+hspace :: (MonadParsec e s m, Token s ~ Char) => m ()
+hspace = void $ takeWhileP (Just "white space") isHSpace
+{-# INLINE hspace #-}
+
 -- | Skip /one/ or more white space characters.
 --
 -- See also: 'skipSome' and 'spaceChar'.
@@ -106,6 +115,13 @@ space = void $ takeWhileP (Just "white space") isSpace
 space1 :: (MonadParsec e s m, Token s ~ Char) => m ()
 space1 = void $ takeWhile1P (Just "white space") isSpace
 {-# INLINE space1 #-}
+
+-- | Like 'space1', but does not accept newlines and carriage returns.
+--
+-- @since 8.1.0
+hspace1 :: (MonadParsec e s m, Token s ~ Char) => m ()
+hspace1 = void $ takeWhile1P (Just "white space") isHSpace
+{-# INLINE hspace1 #-}
 
 ----------------------------------------------------------------------------
 -- Categories of characters
@@ -291,3 +307,10 @@ char' c =
       char (toTitle c)
     ]
 {-# INLINE char' #-}
+
+----------------------------------------------------------------------------
+-- Helpers
+
+-- | Is it a horizontal space character?
+isHSpace :: Char -> Bool
+isHSpace x = isSpace x && x /= '\n' && x /= '\r'

--- a/Text/Megaparsec/Char/Lexer.hs
+++ b/Text/Megaparsec/Char/Lexer.hs
@@ -256,7 +256,8 @@ indentBlock sc r = do
       pos <- C.eol *> indentGuard sc GT ref
       let lvl = fromMaybe pos indent
       x <-
-        if  | pos <= ref -> incorrectIndent GT ref pos
+        if
+            | pos <= ref -> incorrectIndent GT ref pos
             | pos == lvl -> p
             | otherwise -> incorrectIndent EQ lvl pos
       xs <- indentedItems ref lvl sc p
@@ -285,7 +286,8 @@ indentedItems ref lvl sc p = go
       if done
         then return []
         else
-          if  | pos <= ref -> return []
+          if
+              | pos <= ref -> return []
               | pos == lvl -> (:) <$> p <*> go
               | otherwise -> incorrectIndent EQ lvl pos
 

--- a/Text/Megaparsec/Stream.hs
+++ b/Text/Megaparsec/Stream.hs
@@ -367,7 +367,8 @@ reachOffset'
         let SourcePos n l c = apos
             c' = unPos c
             w = unPos pstateTabWidth
-         in if  | ch == newlineTok ->
+         in if
+                | ch == newlineTok ->
                   St
                     (SourcePos n (l <> pos1) pos1)
                     id
@@ -417,7 +418,8 @@ reachOffsetNoLine'
       go (SourcePos n l c) ch =
         let c' = unPos c
             w = unPos pstateTabWidth
-         in if  | ch == newlineTok ->
+         in if
+                | ch == newlineTok ->
                   SourcePos n (l <> pos1) pos1
                 | ch == tabTok ->
                   SourcePos n l (mkPos $ c' + w - ((c' - 1) `rem` w))

--- a/megaparsec-tests/tests/Text/Megaparsec/Char/LexerSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/Char/LexerSpec.hs
@@ -131,7 +131,8 @@ spec = do
               >>= \x -> sp >> ip EQ x >> sp >> ip GT x >> sp >> scn
             ip = indentGuard scn
             sp = void (symbol sc sbla <* C.eol)
-        if  | col0 <= pos1 ->
+        if
+            | col0 <= pos1 ->
               prs p s `shouldFailWith` errFancy 0 (ii GT pos1 col0)
             | col1 /= col0 ->
               prs p s `shouldFailWith` errFancy (getIndent l1 + g 1) (ii EQ col0 col1)
@@ -178,7 +179,8 @@ spec = do
               b = symbol sc
               l x = return . (x,)
               ib' = mkPos (fromIntegral ib)
-          if  | col1 <= col0 ->
+          if
+              | col1 <= col0 ->
                 prs p s
                   `shouldFailWith` err (getIndent l1 + g 1) (utok (head sblb) <> eeof)
               | isJust mn && col1 /= ib' ->
@@ -282,7 +284,8 @@ spec = do
             s = concat fragments
             (col0, col1, col2) = (getCol l0, getCol l1, getCol l2)
             (end0, end1) = (getEnd l0, getEnd l1)
-        if  | end0 && col1 <= col0 ->
+        if
+            | end0 && col1 <= col0 ->
               prs p s
                 `shouldFailWith` errFancy (getIndent l1 + g 1) (ii GT col0 col1)
             | end1 && col2 <= col0 ->

--- a/megaparsec-tests/tests/Text/MegaparsecSpec.hs
+++ b/megaparsec-tests/tests/Text/MegaparsecSpec.hs
@@ -1410,7 +1410,7 @@ spec = do
         runParser' p st `shouldBe` (st', Right stateInput)
 
     describe "atEnd" $ do
-      let p , p' :: Parser Bool
+      let p, p' :: Parser Bool
           p = atEnd
           p' = p <* empty
       context "when stream is empty" $ do


### PR DESCRIPTION
Close #408.

These functions are slightly more specific versions of the existing `space` functions. They accept only “horizontal whitespace”.