### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/megaparsec-tests/megaparsec-tests.cabal
+++ b/megaparsec-tests/megaparsec-tests.cabal
@@ -26,7 +26,7 @@ library
     build-depends:
         QuickCheck >=2.10 && <2.15,
         base >=4.12 && <5.0,
-        bytestring >=0.2 && <0.11,
+        bytestring >=0.2 && <0.12,
         containers >=0.5 && <0.7,
         hspec >=2.0 && <3.0,
         hspec-expectations >=0.8 && <0.9,
@@ -64,7 +64,7 @@ test-suite tests
     build-depends:
         QuickCheck >=2.10 && <2.15,
         base >=4.12 && <5.0,
-        bytestring >=0.2 && <0.11,
+        bytestring >=0.2 && <0.12,
         case-insensitive >=1.2 && <1.3,
         containers >=0.5 && <0.7,
         hspec >=2.0 && <3.0,

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -56,7 +56,7 @@ library
     default-language: Haskell2010
     build-depends:
         base >=4.12 && <5.0,
-        bytestring >=0.2 && <0.11,
+        bytestring >=0.2 && <0.12,
         case-insensitive >=1.2 && <1.3,
         containers >=0.5 && <0.7,
         deepseq >=1.3 && <1.5,


### PR DESCRIPTION
Tested using
```cabal
packages: megaparsec.cabal
        , megaparsec-tests/megaparsec-tests.cabal

constraints:
  bytestring >= 0.11

allow-newer:
  text:bytestring
```