### PR TITLE
Fix Haddock link to Text.Megaparsec.Char.space1

### DIFF
--- a/Text/Megaparsec/Lexer.hs
+++ b/Text/Megaparsec/Lexer.hs
@@ -36,11 +36,11 @@ import Text.Megaparsec.Common
 -- @spaceConsumer@ in documentation, usually it means that something like
 -- 'space' is expected there).
 --
--- @sc@ is used to parse blocks of space characters. You can use 'C.space1'
+-- @sc@ is used to parse blocks of space characters. You can use 'Text.Megaparsec.Char.space1'
 -- from "Text.Megaparsec.Char" for this purpose as well as your own parser
 -- (if you don't want to automatically consume newlines, for example). Make
 -- sure the parser does not succeed on empty input though. In earlier
--- version 'C.spaceChar' was recommended, but now parsers based on
+-- version 'spaceChar' was recommended, but now parsers based on
 -- 'takeWhile1P' are preferred because of their speed.
 --
 -- @lineComment@ is used to parse line comments. You can use
@@ -57,7 +57,7 @@ import Text.Megaparsec.Common
 space ::
   MonadParsec e s m =>
   -- | A parser for space characters which does not accept empty
-  -- input (e.g. 'C.space1')
+  -- input (e.g. 'Text.Megaparsec.Char.space1')
   m () ->
   -- | A parser for a line comment (e.g. 'skipLineComment')
   m () ->

--- a/Text/Megaparsec/Lexer.hs
+++ b/Text/Megaparsec/Lexer.hs
@@ -40,7 +40,7 @@ import Text.Megaparsec.Common
 -- from "Text.Megaparsec.Char" for this purpose as well as your own parser
 -- (if you don't want to automatically consume newlines, for example). Make
 -- sure the parser does not succeed on empty input though. In earlier
--- version 'spaceChar' was recommended, but now parsers based on
+-- version 'Text.Megaparsec.Char.spaceChar' was recommended, but now parsers based on
 -- 'takeWhile1P' are preferred because of their speed.
 --
 -- @lineComment@ is used to parse line comments. You can use


### PR DESCRIPTION
The Haddock links for `space1` don't currently go anywhere.  This PR fixes these links:

https://hackage.haskell.org/package/megaparsec-9.0.1/docs/Text-Megaparsec-Char-Lexer.html

My guess is that `Text.Megaparsec.Char.Lexer` was imported qualified as `C`, so the links used to work, but that import has since been removed.