### PR TITLE
Add a type class for parser monads with debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   negative, similar to when `n == 0`. [Issue
   497](https://github.com/mrkkrp/megaparsec/issues/497).
 
+* Added the `MonadParsecDbg` type class in `Text.Megaparsec.Debug`. The type
+  class allows us to use `dbg` in MTL monad transformers. [Issue
+  488](https://github.com/mrkkrp/megaparsec/issues/488)
+
 ## Megaparsec 9.2.2
 
 * Fixed a space leak in the implementations of the `reachOffset` and

--- a/Text/Megaparsec/Debug.hs
+++ b/Text/Megaparsec/Debug.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Unsafe #-}
 
@@ -15,102 +17,226 @@
 --
 -- @since 7.0.0
 module Text.Megaparsec.Debug
-  ( dbg,
+  ( MonadParsecDbg (..),
     dbg',
   )
 where
 
+import Control.Monad.Identity (IdentityT, mapIdentityT)
+import qualified Control.Monad.Trans.RWS.Lazy as L
+import qualified Control.Monad.Trans.RWS.Strict as S
+import qualified Control.Monad.Trans.Reader as L
+import qualified Control.Monad.Trans.State.Lazy as L
+import qualified Control.Monad.Trans.State.Strict as S
+import qualified Control.Monad.Trans.Writer.Lazy as L
+import qualified Control.Monad.Trans.Writer.Strict as S
+import Data.Bifunctor (Bifunctor (first))
 import qualified Data.List.NonEmpty as NE
 import Data.Proxy
 import Debug.Trace
+import Text.Megaparsec.Class (MonadParsec)
 import Text.Megaparsec.Error
 import Text.Megaparsec.Internal
 import Text.Megaparsec.State
 import Text.Megaparsec.Stream
 
--- | @'dbg' label p@ parser works exactly like @p@, but when it's evaluated
--- it prints information useful for debugging. The @label@ is only used to
--- refer to this parser in the debugging output. This combinator uses the
--- 'trace' function from "Debug.Trace" under the hood.
+-- | Type class describing parser monads that can trace during evaluation.
 --
--- Typical usage is to wrap every sub-parser in misbehaving parser with
--- 'dbg' assigning meaningful labels. Then give it a shot and go through the
--- print-out. As of current version, this combinator prints all available
--- information except for /hints/, which are probably only interesting to
--- the maintainer of Megaparsec itself and may be quite verbose to output in
--- general. Let me know if you would like to be able to see hints in the
--- debugging output.
+-- @since 9.3.0
+class MonadParsec e s m => MonadParsecDbg e s m where
+  -- | @'dbg' label p@ parser works exactly like @p@, but when it's evaluated
+  -- it prints information useful for debugging. The @label@ is only used to
+  -- refer to this parser in the debugging output. This combinator uses the
+  -- 'trace' function from "Debug.Trace" under the hood.
+  --
+  -- Typical usage is to wrap every sub-parser in misbehaving parser with
+  -- 'dbg' assigning meaningful labels. Then give it a shot and go through the
+  -- print-out. As of current version, this combinator prints all available
+  -- information except for /hints/, which are probably only interesting to
+  -- the maintainer of Megaparsec itself and may be quite verbose to output in
+  -- general. Let me know if you would like to be able to see hints in the
+  -- debugging output.
+  --
+  -- The output itself is pretty self-explanatory, although the following
+  -- abbreviations should be clarified (they are derived from the low-level
+  -- source code):
+  --
+  --     * @COK@—“consumed OK”. The parser consumed input and succeeded.
+  --     * @CERR@—“consumed error”. The parser consumed input and failed.
+  --     * @EOK@—“empty OK”. The parser succeeded without consuming input.
+  --     * @EERR@—“empty error”. The parser failed without consuming input.
+  --
+  -- __Note__: up until the version /9.3.0/ this was a non-polymorphic
+  -- function that worked only in 'ParsecT'. It was first introduced in the
+  -- version /7.0.0/.
+  dbg ::
+    Show a =>
+    -- | Debugging label
+    String ->
+    -- | Parser to debug
+    m a ->
+    -- | Parser that prints debugging messages
+    m a
+
+-- | @dbg (p :: StateT st m)@ prints state __after__ running @p@:
 --
--- The output itself is pretty self-explanatory, although the following
--- abbreviations should be clarified (they are derived from the low-level
--- source code):
+-- >>> p = modify succ >> dbg "a" (single 'a' >> modify succ)
+-- >>> parseTest (runStateT p 0) "a"
+-- a> IN: 'a'
+-- a> MATCH (COK): 'a'
+-- a> VALUE: () (STATE: 2)
+-- ((),2)
+instance
+  (Show st, MonadParsecDbg e s m) =>
+  MonadParsecDbg e s (L.StateT st m)
+  where
+  dbg str sma = L.StateT $ \s ->
+    dbgWithComment "STATE" str $ L.runStateT sma s
+
+-- | @dbg (p :: StateT st m)@ prints state __after__ running @p@:
 --
---     * @COK@—“consumed OK”. The parser consumed input and succeeded.
---     * @CERR@—“consumed error”. The parser consumed input and failed.
---     * @EOK@—“empty OK”. The parser succeeded without consuming input.
---     * @EERR@—“empty error”. The parser failed without consuming input.
+-- >>> p = modify succ >> dbg "a" (single 'a' >> modify succ)
+-- >>> parseTest (runStateT p 0) "a"
+-- a> IN: 'a'
+-- a> MATCH (COK): 'a'
+-- a> VALUE: () (STATE: 2)
+-- ((),2)
+instance
+  (Show st, MonadParsecDbg e s m) =>
+  MonadParsecDbg e s (S.StateT st m)
+  where
+  dbg str sma = S.StateT $ \s ->
+    dbgWithComment "STATE" str $ S.runStateT sma s
+
+instance
+  MonadParsecDbg e s m =>
+  MonadParsecDbg e s (L.ReaderT r m)
+  where
+  dbg = L.mapReaderT . dbg
+
+-- | @dbg (p :: WriterT st m)@ prints __only__ log produced by @p@:
 --
--- Finally, it's not possible to lift this function into some monad
--- transformers without introducing surprising behavior (e.g. unexpected
--- state backtracking) or adding otherwise redundant constraints (e.g.
--- 'Show' instance for state), so this helper is only available for
--- 'ParsecT' monad, not any instance of 'Text.Megaparsec.MonadParsec' in
--- general.
-dbg ::
-  forall e s m a.
-  ( VisualStream s,
-    ShowErrorComponent e,
-    Show a
-  ) =>
-  -- | Debugging label
+-- >>> p = tell [0] >> dbg "a" (single 'a' >> tell [1])
+-- >>> parseTest (runWriterT p) "a"
+-- a> IN: 'a'
+-- a> MATCH (COK): 'a'
+-- a> VALUE: () (LOG: [1])
+-- ((),[0,1])
+instance
+  (Monoid w, Show w, MonadParsecDbg e s m) =>
+  MonadParsecDbg e s (L.WriterT w m)
+  where
+  dbg str wma = L.WriterT $ dbgWithComment "LOG" str $ L.runWriterT wma
+
+-- | @dbg (p :: WriterT st m)@ prints __only__ log produced by @p@:
+--
+-- >>> p = tell [0] >> dbg "a" (single 'a' >> tell [1])
+-- >>> parseTest (runWriterT p) "a"
+-- a> IN: 'a'
+-- a> MATCH (COK): 'a'
+-- a> VALUE: () (LOG: [1])
+-- ((),[0,1])
+instance
+  (Monoid w, Show w, MonadParsecDbg e s m) =>
+  MonadParsecDbg e s (S.WriterT w m)
+  where
+  dbg str wma = S.WriterT $ dbgWithComment "LOG" str $ S.runWriterT wma
+
+-- | @RWST@ works like @StateT@ inside a @WriterT@: subparser's log and its
+-- final state is printed:
+--
+-- >>> p = tell [0] >> modify succ >> dbg "a" (single 'a' >> tell [1] >> modify succ)
+-- >>> parseTest (runRWST p () 0) "a"
+-- a> IN: 'a'
+-- a> MATCH (COK): 'a'
+-- a> VALUE: () (STATE: 2) (LOG: [1])
+-- ((),2,[0,1])
+instance
+  (Monoid w, Show w, Show st, MonadParsecDbg e s m) =>
+  MonadParsecDbg e s (L.RWST r w st m)
+  where
+  dbg str sma = L.RWST $ \r s -> do
+    let smth =
+          (\(a, st, w) -> ShowComment "LOG" (ShowComment "STATE" (a, st), w))
+            <$> L.runRWST sma r s
+    ((a, st), w) <- first unComment . unComment <$> dbg str smth
+    pure (a, st, w)
+
+-- | @RWST@ works like @StateT@ inside a @WriterT@: subparser's log and its
+-- final state is printed:
+--
+-- >>> p = tell [0] >> modify succ >> dbg "a" (single 'a' >> tell [1] >> modify succ)
+-- >>> parseTest (runRWST p () 0) "a"
+-- a> IN: 'a'
+-- a> MATCH (COK): 'a'
+-- a> VALUE: () (STATE: 2) (LOG: [1])
+-- ((),2,[0,1])
+instance
+  (Monoid w, Show w, Show st, MonadParsecDbg e s m) =>
+  MonadParsecDbg e s (S.RWST r w st m)
+  where
+  dbg str sma = S.RWST $ \r s -> do
+    let smth =
+          (\(a, st, w) -> ShowComment "LOG" (ShowComment "STATE" (a, st), w))
+            <$> S.runRWST sma r s
+    ((a, st), w) <- first unComment . unComment <$> dbg str smth
+    pure (a, st, w)
+
+instance MonadParsecDbg e s m => MonadParsecDbg e s (IdentityT m) where
+  dbg = mapIdentityT . dbg
+
+-- | @'dbgWithComment' label_a label_c m@ traces the first component of the
+-- result produced by @m@ with @label_a@ and the second component with
+-- @label_b@.
+dbgWithComment ::
+  (MonadParsecDbg e s m, Show a, Show c) =>
+  -- | Debugging label (for @a@)
+  String ->
+  -- | Extra component label (for @c@)
   String ->
   -- | Parser to debug
-  ParsecT e s m a ->
+  m (a, c) ->
   -- | Parser that prints debugging messages
-  ParsecT e s m a
-dbg lbl p = ParsecT $ \s cok cerr eok eerr ->
-  let l = dbgLog lbl :: DbgItem s e a -> String
-      unfold = streamTake 40
-      cok' x s' hs =
-        flip trace (cok x s' hs) $
-          l (DbgIn (unfold (stateInput s)))
-            ++ l (DbgCOK (streamTake (streamDelta s s') (stateInput s)) x)
-      cerr' err s' =
-        flip trace (cerr err s') $
-          l (DbgIn (unfold (stateInput s)))
-            ++ l (DbgCERR (streamTake (streamDelta s s') (stateInput s)) err)
-      eok' x s' hs =
-        flip trace (eok x s' hs) $
-          l (DbgIn (unfold (stateInput s)))
-            ++ l (DbgEOK (streamTake (streamDelta s s') (stateInput s)) x)
-      eerr' err s' =
-        flip trace (eerr err s') $
-          l (DbgIn (unfold (stateInput s)))
-            ++ l (DbgEERR (streamTake (streamDelta s s') (stateInput s)) err)
-   in unParser p s cok' cerr' eok' eerr'
+  m (a, c)
+dbgWithComment lbl str ma =
+  unComment <$> dbg str (ShowComment lbl <$> ma)
 
--- | Just like 'dbg', but doesn't require the return value of the parser to
--- be 'Show'-able.
+-- | A wrapper with a special show instance:
 --
--- @since 9.1.0
-dbg' ::
-  forall e s m a.
-  ( VisualStream s,
-    ShowErrorComponent e
-  ) =>
-  -- | Debugging label
-  String ->
-  -- | Parser to debug
-  ParsecT e s m a ->
-  -- | Parser that prints debugging messages
-  ParsecT e s m a
-dbg' lbl p = unBlind <$> dbg lbl (Blind <$> p)
+-- >>> show (ShowComment "STATE" ("Hello, world!", 42))
+-- Hello, world! (STATE: 42)
+data ShowComment c a = ShowComment String (a, c)
 
--- | A wrapper type with a dummy 'Show' instance.
-newtype Blind x = Blind {unBlind :: x}
+unComment :: ShowComment c a -> (a, c)
+unComment (ShowComment _ val) = val
 
-instance Show (Blind x) where
-  show _ = "NOT SHOWN"
+instance (Show c, Show a) => Show (ShowComment c a) where
+  show (ShowComment lbl (a, c)) = show a ++ " (" ++ lbl ++ ": " ++ show c ++ ")"
+
+instance
+  (VisualStream s, ShowErrorComponent e) =>
+  MonadParsecDbg e s (ParsecT e s m)
+  where
+  dbg lbl p = ParsecT $ \s cok cerr eok eerr ->
+    let l = dbgLog lbl
+        unfold = streamTake 40
+        cok' x s' hs =
+          flip trace (cok x s' hs) $
+            l (DbgIn (unfold (stateInput s)))
+              ++ l (DbgCOK (streamTake (streamDelta s s') (stateInput s)) x)
+        cerr' err s' =
+          flip trace (cerr err s') $
+            l (DbgIn (unfold (stateInput s)))
+              ++ l (DbgCERR (streamTake (streamDelta s s') (stateInput s)) err)
+        eok' x s' hs =
+          flip trace (eok x s' hs) $
+            l (DbgIn (unfold (stateInput s)))
+              ++ l (DbgEOK (streamTake (streamDelta s s') (stateInput s)) x)
+        eerr' err s' =
+          flip trace (eerr err s') $
+            l (DbgIn (unfold (stateInput s)))
+              ++ l (DbgEERR (streamTake (streamDelta s s') (stateInput s)) err)
+     in unParser p s cok' cerr' eok' eerr'
 
 -- | A single piece of info to be rendered with 'dbgLog'.
 data DbgItem s e a
@@ -172,3 +298,23 @@ streamTake n s =
   case fst <$> takeN_ n s of
     Nothing -> []
     Just chk -> chunkToTokens (Proxy :: Proxy s) chk
+
+-- | Just like 'dbg', but doesn't require the return value of the parser to
+-- be 'Show'-able.
+--
+-- @since 9.1.0
+dbg' ::
+  MonadParsecDbg e s m =>
+  -- | Debugging label
+  String ->
+  -- | Parser to debug
+  m a ->
+  -- | Parser that prints debugging messages
+  m a
+dbg' lbl p = unBlind <$> dbg lbl (Blind <$> p)
+
+-- | A wrapper type with a dummy 'Show' instance.
+newtype Blind x = Blind {unBlind :: x}
+
+instance Show (Blind x) where
+  show _ = "NOT SHOWN"

--- a/megaparsec-tests/megaparsec-tests.cabal
+++ b/megaparsec-tests/megaparsec-tests.cabal
@@ -76,6 +76,7 @@ test-suite tests
         mtl >=2.2.2 && <3.0,
         parser-combinators >=1.0 && <2.0,
         scientific >=0.3.1 && <0.4,
+        temporary >=1.1 && <1.4,
         text >=0.2 && <2.1,
         transformers >=0.4 && <0.7
 

--- a/megaparsec-tests/src/Test/Hspec/Megaparsec/AdHoc.hs
+++ b/megaparsec-tests/src/Test/Hspec/Megaparsec/AdHoc.hs
@@ -71,6 +71,7 @@ import Test.Hspec
 import Test.Hspec.Megaparsec
 import Test.QuickCheck
 import Text.Megaparsec
+import Text.Megaparsec.Debug (MonadParsecDbg)
 
 ----------------------------------------------------------------------------
 -- Types
@@ -120,7 +121,7 @@ prs_ p = parse (p <* eof) ""
 -- all supported monads transformers in turn).
 grs ::
   -- | Parser to run
-  (forall m. MonadParsec Void String m => m a) ->
+  (forall m. MonadParsecDbg Void String m => m a) ->
   -- | Input for the parser
   String ->
   -- | How to check result of parsing
@@ -140,7 +141,7 @@ grs p s r = do
 -- | 'grs'' to 'grs' is as 'prs'' to 'prs'.
 grs' ::
   -- | Parser to run
-  (forall m. MonadParsec Void String m => m a) ->
+  (forall m. MonadParsecDbg Void String m => m a) ->
   -- | Input for the parser
   String ->
   -- | How to check result of parsing

--- a/megaparsec-tests/tests/Text/Megaparsec/DebugSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/DebugSpec.hs
@@ -1,8 +1,23 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Text.Megaparsec.DebugSpec (spec) where
 
+import Control.Exception (evaluate)
 import Control.Monad
+import Control.Monad.RWS (MonadRWS)
+import qualified Control.Monad.RWS.Lazy as L
+import qualified Control.Monad.RWS.Strict as S
+import Control.Monad.State (MonadState (..), modify)
+import qualified Control.Monad.State.Lazy as L
+import qualified Control.Monad.State.Strict as S
+import Control.Monad.Writer (MonadWriter (..))
+import qualified Control.Monad.Writer.Lazy as L
+import qualified Control.Monad.Writer.Strict as S
+import Data.Void
+import GHC.IO.Handle
+import System.IO (stderr)
+import System.IO.Temp
 import Test.Hspec
 import Test.Hspec.Megaparsec
 import Test.Hspec.Megaparsec.AdHoc
@@ -13,39 +28,170 @@ import Text.Megaparsec.Debug
 spec :: Spec
 spec = do
   describe "dbg" $ do
-    -- NOTE We don't test properties here to avoid a flood of debugging
-    -- output when the test runs.
     context "when inner parser succeeds consuming input" $ do
       it "has no effect on how parser works" $ do
-        let p = dbg "char" (char 'a')
+        let p :: MonadParsecDbg Void String m => m Char
+            p = dbg "char" (char 'a')
             s = "ab"
-        prs p s `shouldParse` 'a'
-        prs' p s `succeedsLeaving` "b"
+        shouldStderr p s "char> IN: \"ab\"\nchar> MATCH (COK): 'a'\nchar> VALUE: 'a'\n\n"
+        grs p s (`shouldParse` 'a')
+        grs' p s (`succeedsLeaving` "b")
       it "its hints are preserved" $ do
-        let p = dbg "many chars" (many (char 'a')) <* empty
+        let p :: MonadParsecDbg Void String m => m String
+            p = dbg "many chars" (many (char 'a')) <* empty
             s = "abcd"
-        prs p s `shouldFailWith` err 1 (etok 'a')
-        prs' p s `failsLeaving` "bcd"
+        shouldStderr p s "many chars> IN: \"abcd\"\nmany chars> MATCH (COK): 'a'\nmany chars> VALUE: \"a\"\n\n"
+        grs p s (`shouldFailWith` err 1 (etok 'a'))
+        grs' p s (`failsLeaving` "bcd")
     context "when inner parser fails consuming input" $
       it "has no effect on how parser works" $ do
-        let p = dbg "chars" (char 'a' *> char 'c')
+        let p :: MonadParsecDbg Void String m => m Char
+            p = dbg "chars" (char 'a' *> char 'c')
             s = "abc"
-        prs p s `shouldFailWith` err 1 (utok 'b' <> etok 'c')
-        prs' p s `failsLeaving` "bc"
+        shouldStderr p s "chars> IN: \"abc\"\nchars> MATCH (CERR): 'a'\nchars> ERROR:\nchars> offset=1:\nchars> unexpected 'b'\nchars> expecting 'c'\n\n"
+        grs p s (`shouldFailWith` err 1 (utok 'b' <> etok 'c'))
+        grs' p s (`failsLeaving` "bc")
     context "when inner parser succeeds without consuming" $ do
       it "has no effect on how parser works" $ do
-        let p = dbg "return" (return 'a')
+        let p :: MonadParsecDbg Void String m => m Char
+            p = dbg "return" (return 'a')
             s = "abc"
-        prs p s `shouldParse` 'a'
-        prs' p s `succeedsLeaving` s
+        shouldStderr p s "return> IN: \"abc\"\nreturn> MATCH (EOK): <EMPTY>\nreturn> VALUE: 'a'\n\n"
+        grs p s (`shouldParse` 'a')
+        grs' p s (`succeedsLeaving` s)
       it "its hints are preserved" $ do
-        let p = dbg "many chars" (many (char 'a')) <* empty
+        let p :: MonadParsecDbg Void String m => m String
+            p = dbg "many chars" (many (char 'a')) <* empty
             s = "bcd"
-        prs p s `shouldFailWith` err 0 (etok 'a')
-        prs' p s `failsLeaving` "bcd"
+        shouldStderr p s "many chars> IN: \"bcd\"\nmany chars> MATCH (EOK): <EMPTY>\nmany chars> VALUE: \"\"\n\n"
+        grs p s (`shouldFailWith` err 0 (etok 'a'))
+        grs' p s (`failsLeaving` "bcd")
     context "when inner parser fails without consuming" $
       it "has no effect on how parser works" $ do
-        let p = dbg "empty" (void empty)
+        let p :: MonadParsecDbg Void String m => m ()
+            p = dbg "empty" (void empty)
             s = "abc"
-        prs p s `shouldFailWith` err 0 mempty
-        prs' p s `failsLeaving` s
+        shouldStderr p s "empty> IN: \"abc\"\nempty> MATCH (EERR): <EMPTY>\nempty> ERROR:\nempty> offset=0:\nempty> unknown parse error\n\n"
+        grs p s (`shouldFailWith` err 0 mempty)
+        grs' p s (`failsLeaving` s)
+    let p1, p2 :: (MonadParsecDbg Void String m, MonadWriter [Int] m) => m ()
+        p1 = tell [0] >> dbg "a" (single 'a' >> tell [1])
+        p2 = do
+          void $ dbg "a" (single 'a')
+          tell [0]
+          void $ dbg "b" (single 'b')
+          dbg "c" $ do
+            void (single 'c')
+            tell [1]
+            void (single 'd')
+            tell [2]
+        s1 = "a"
+        s2 = "abcd"
+        stderr1 = "a> IN: 'a'\na> MATCH (COK): 'a'\na> VALUE: () (LOG: [1])\n\n"
+        stderr2 = "a> IN: \"abcd\"\na> MATCH (COK): 'a'\na> VALUE: 'a' (LOG: [])\n\nb> IN: \"bcd\"\nb> MATCH (COK): 'b'\nb> VALUE: 'b' (LOG: [])\n\nc> IN: \"cd\"\nc> MATCH (COK): \"cd\"\nc> VALUE: () (LOG: [1,2])\n\n"
+        r1 = ((), [0, 1])
+        r2 = ((), [0, 1, 2])
+    context "Lazy WriterT instance of MonadParsecDbg" $ do
+      it "example 1" $ do
+        shouldStderr (L.runWriterT p1) s1 stderr1
+        prs (L.runWriterT p1) s1 `shouldParse` r1
+      it "example 2" $ do
+        shouldStderr (L.runWriterT p2) s2 stderr2
+        prs (L.runWriterT p2) s2 `shouldParse` r2
+    context "Strict WriterT instance of MonadParsecDbg" $ do
+      it "example 1" $ do
+        shouldStderr (S.runWriterT p1) s1 stderr1
+        prs (S.runWriterT p1) s1 `shouldParse` r1
+      it "example 2" $ do
+        shouldStderr (S.runWriterT p2) s2 stderr2
+        prs (S.runWriterT p2) s2 `shouldParse` r2
+    let p3, p4 :: (MonadParsecDbg Void String m, MonadState Int m) => m ()
+        p3 = modify succ >> dbg "a" (single 'a' >> modify succ)
+        p4 = do
+          void $ dbg "a" (single 'a')
+          modify succ
+          void $ dbg "b" (single 'b')
+          dbg "c" $ do
+            void (single 'c')
+            modify succ
+            void (single 'd')
+            modify succ
+        s3 = "a"
+        s4 = "abcd"
+        stderr3 = "a> IN: 'a'\na> MATCH (COK): 'a'\na> VALUE: () (STATE: 2)\n\n"
+        stderr4 = "a> IN: \"abcd\"\na> MATCH (COK): 'a'\na> VALUE: 'a' (STATE: 0)\n\nb> IN: \"bcd\"\nb> MATCH (COK): 'b'\nb> VALUE: 'b' (STATE: 1)\n\nc> IN: \"cd\"\nc> MATCH (COK): \"cd\"\nc> VALUE: () (STATE: 3)\n\n"
+        r3 = ((), 2)
+        r4 = ((), 3)
+    context "Lazy StateT instance of MonadParsecDbg" $ do
+      it "example 3" $ do
+        shouldStderr (L.runStateT p3 0) s3 stderr3
+        prs (L.runStateT p3 0) s3 `shouldParse` r3
+      it "example 4" $ do
+        shouldStderr (L.runStateT p4 0) s4 stderr4
+        prs (L.runStateT p4 0) s4 `shouldParse` r4
+    context "Strict StateT instance of MonadParsecDbg" $ do
+      it "example 3" $ do
+        shouldStderr (S.runStateT p3 0) s3 stderr3
+        prs (S.runStateT p3 0) s3 `shouldParse` r3
+      it "example 4" $ do
+        shouldStderr (S.runStateT p4 0) s4 stderr4
+        prs (S.runStateT p4 0) s4 `shouldParse` r4
+    let p5 :: (MonadParsecDbg Void String m, MonadRWS () [Int] Int m) => m ()
+        p5 = do
+          tell [0]
+          modify succ
+          dbg "a" (single 'a' >> tell [1] >> modify succ)
+        s5 = "a"
+        stderr5 = "a> IN: 'a'\na> MATCH (COK): 'a'\na> VALUE: () (STATE: 2) (LOG: [1])\n\n"
+        stderr7 = "a> IN: 'a'\na> MATCH (COK): 'a'\na> VALUE: () (LOG: [1]) (STATE: 2)\n\n"
+        r5 = ((), 2, [0, 1])
+        p6 :: (MonadParsecDbg Void String m, MonadWriter [Int] m, MonadState Int m) => m ()
+        p6 = do
+          tell [0]
+          modify succ
+          dbg "a" (single 'a' >> tell [1] >> modify succ)
+        r6 = (((), 2), [0, 1])
+        r7 = (((), [0, 1]), 2)
+    context "Lazy RWST instance of MonadParsecDbg" $ do
+      it "example 5" $ do
+        shouldStderr (L.runRWST p5 () 0) s5 stderr5
+        prs (L.runRWST p5 () 0) s5 `shouldParse` r5
+      it "example 6" $ do
+        shouldStderr (L.runWriterT (L.runStateT p6 0)) s5 stderr5
+        prs (L.runWriterT (L.runStateT p6 0)) s5 `shouldParse` r6
+      it "example 7" $ do
+        shouldStderr (L.runStateT (L.runWriterT p6) 0) s5 stderr7
+        prs (L.runStateT (L.runWriterT p6) 0) s5 `shouldParse` r7
+    context "Strict RWST instance of MonadParsecDbg" $ do
+      it "example 5" $ do
+        shouldStderr (S.runRWST p5 () 0) s5 stderr5
+        prs (S.runRWST p5 () 0) s5 `shouldParse` r5
+      it "example 6" $ do
+        shouldStderr (S.runWriterT (S.runStateT p6 0)) s5 stderr5
+        prs (S.runWriterT (S.runStateT p6 0)) s5 `shouldParse` r6
+      it "example 7" $ do
+        shouldStderr (S.runStateT (S.runWriterT p6) 0) s5 stderr7
+        prs (S.runStateT (S.runWriterT p6) 0) s5 `shouldParse` r7
+
+----------------------------------------------------------------------------
+-- Helpers
+
+-- | Check that running the given parser on the input prints the expected
+-- string to the 'stderr'.
+shouldStderr ::
+  -- | The parser to test
+  Parser a ->
+  -- | Input for the parser
+  String ->
+  -- | The expected 'stderr' output
+  String ->
+  Expectation
+shouldStderr p s expectedStderr = do
+  hFlush stderr
+  withSystemTempFile "megaparsec-dbg-tests" $ \tempPath tempHandle -> do
+    hDuplicateTo tempHandle stderr
+    void (evaluate (parse p "" s))
+    hFlush stderr
+    hClose tempHandle
+    capturedStderr <- readFile tempPath
+    capturedStderr `shouldBe` expectedStderr


### PR DESCRIPTION
Close #488.

`MonadParsecDbg` class and instances for `MonadParsecT`, `ReaderT`, `WriterT`, `StateT` and `RWST` added.

There are some difficulties with testing these changes, because they use `trace` and thefore can not be tested by `hspec`. To work around this, I've added separate `test-debug` executablle into `megaparsec-tests` for running some parsers manually and checking produced ouput with my eyes. Maybe, this is not a good solution, but I have not found any better.

Futhermore, I have no `nix-shell` and it will be not very easy to run tests (I'm working on Windows). For instance, the `cabal test all` failed with `commitBuffer: invalid argument (invalid character)`. I don't think that my changes should break anything, however.
