### PR TITLE
Explicitly copy token sequences to avoid sharing input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   class allows us to use `dbg` in MTL monad transformers. [Issue
   488](https://github.com/mrkkrp/megaparsec/issues/488).
 
+* Introduced the `ShareInput` and `NoShareInput` newtype wrappers in
+  `Text.Megaparsec.Stream` in order to allow the user to choose how the
+  input should be sliced and shared during the parsing. [Issue
+  492](https://github.com/mrkkrp/megaparsec/issues/492).
+
 ## Megaparsec 9.2.2
 
 * Fixed a space leak in the implementations of the `reachOffset` and


### PR DESCRIPTION
Closes https://github.com/mrkkrp/megaparsec/issues/492

As mentioned in the issue, we can avoid leaking memory retaining the input in memory by explicitly copying token sequences as we read them.

The performance implications of adding an explicit `copy` to `takeN_` and `takeWhile_` are as follows:
- The `takeWhileP` family of basic combinators end up consuming a lot more memory (since previously they didn't need to allocate the result buffer) and time (due to the `copy` call).
- The `decimal` (`octal` etc) family of combinators are about 40% slower and consume about twice as much memory. 
- All other combinators (like `many`) have either stayed the same or got slightly (up to 10%) faster.

Sadly we don't have any real-world benchmarks (or do we?) so it's hard to tell if this would have any significant impact in practice.

### Raw benchmark results
This PR: [memory](https://github.com/mrkkrp/megaparsec/files/9885725/copy_memory.txt) [speed](https://github.com/mrkkrp/megaparsec/files/9885726/copy_speed.txt)
Master: [memory](https://github.com/mrkkrp/megaparsec/files/9885727/master_memory.txt) [speed](https://github.com/mrkkrp/megaparsec/files/9885728/master_speed.txt)
