### PR TITLE
Implement mkParsec—a new method of MonadParsec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 * Hints are no longer lost in certain methods of MTL instances for
   `ParsecT`. [Issue 528](https://github.com/mrkkrp/megaparsec/issues/528).
 
+* Added a new method to the `MonadParsec` type class—`mkParsec`. This can be
+  used to construct “new primitives” with arbitrary behavior at the expense
+  of having to dive into Megaparsec's internals. [PR
+  514](https://github.com/mrkkrp/megaparsec/pull/514).
+
 ## Megaparsec 9.3.1
 
 * Fixed a bug related to processing of tabs when error messages are

--- a/Text/Megaparsec/Debug.hs
+++ b/Text/Megaparsec/Debug.hs
@@ -216,7 +216,7 @@ instance (Show c, Show a) => Show (ShowComment c a) where
   show (ShowComment lbl (a, c)) = show a ++ " (" ++ lbl ++ ": " ++ show c ++ ")"
 
 instance
-  (VisualStream s, ShowErrorComponent e) =>
+  (VisualStream s, ShowErrorComponent e, Monad m) =>
   MonadParsecDbg e s (ParsecT e s m)
   where
   dbg lbl p = ParsecT $ \s cok cerr eok eerr ->

--- a/Text/Megaparsec/Internal.hs-boot
+++ b/Text/Megaparsec/Internal.hs-boot
@@ -1,0 +1,10 @@
+{-# LANGUAGE RoleAnnotations #-}
+
+module Text.Megaparsec.Internal
+  ( Reply,
+  )
+where
+
+type role Reply nominal nominal representational
+
+data Reply e s a


### PR DESCRIPTION
Close #366.

Implements a new primitive as discussed in https://github.com/mrkkrp/megaparsec/issues/366#issuecomment-1434839814, which enables defining new primitives, at the cost of needing to drop (a little) into megaparsec internals.