### PR TITLE
Preserve hints in monad transformers operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * `dbg` now prints hints among other debug information. [PR
   530](https://github.com/mrkkrp/megaparsec/pull/530).
 
+* Hints are no longer lost in certain methods of MTL instances for
+  `ParsecT`. [Issue 528](https://github.com/mrkkrp/megaparsec/issues/528).
+
 ## Megaparsec 9.3.1
 
 * Fixed a bug related to processing of tabs when error messages are

--- a/Text/Megaparsec.hs
+++ b/Text/Megaparsec.hs
@@ -288,7 +288,7 @@ runParserT' p s = do
             bundlePosState = statePosState s
           }
   return $ case result of
-    OK x ->
+    OK _ x ->
       case NE.nonEmpty (stateParseErrors s') of
         Nothing -> (s', Right x)
         Just de -> (s', Left (toBundle de))


### PR DESCRIPTION
Closes #528.

I'm not sure about MonadCont and MonadFix instances -- to be honest, I haven't ever used them and don't understand properly, how they should work. At the moment they clear all hints like before. 