### PR TITLE
Print hints in `dbg` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 *Megaparsec follows [SemVer](https://semver.org/).*
 
+## Megaparsec 9.4.0
+
+* `dbg` now prints hints among other debug information. [PR
+  530](https://github.com/mrkkrp/megaparsec/pull/530).
+
 ## Megaparsec 9.3.1
 
 * Fixed a bug related to processing of tabs when error messages are

--- a/Text/Megaparsec/Error.hs
+++ b/Text/Megaparsec/Error.hs
@@ -43,6 +43,7 @@ module Text.Megaparsec.Error
     errorBundlePretty,
     parseErrorPretty,
     parseErrorTextPretty,
+    showErrorItem,
   )
 where
 
@@ -458,6 +459,8 @@ parseErrorTextPretty (FancyError _ xs) =
 -- Helpers
 
 -- | Pretty-print an 'ErrorItem'.
+--
+-- @since 9.4.0
 showErrorItem :: (VisualStream s) => Proxy s -> ErrorItem (Token s) -> String
 showErrorItem pxy = \case
   Tokens ts -> showTokens pxy ts


### PR DESCRIPTION
This is convinient for figuring out where your labels are lost during parsing process.
I had to add `showErrorItem` to `Text.Megaparsec.Error` exports to use it for printing hints in `Text.Megaparsec.Debug`. Maybe there's any better solution. Moreover, there can be many styles of printing hints. I've chosen list-like:
```
HINTS: ['a', 'b', end of file]
```