### PR TITLE
Add MonadWriter instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Dropped a number of redundant constraints here and there. [PR
   523](https://github.com/mrkkrp/megaparsec/pull/523).
 
+* Added a `MonadWriter` instance for `ParsecT`. [PR
+  534](https://github.com/mrkkrp/megaparsec/pull/534).
+
 ## Megaparsec 9.4.1
 
 * Removed `Monad m` constraints in several places where they were introduced


### PR DESCRIPTION
A general function `hoistP` can be used to implement monad transformer class methods of the form `MonadFoo m => m (f a) -> m (g a)` for example `local`, `listen` and `pass`. Usage of `hoistP` becomes more ergonomic when `Result` and `Reply` have `Traversable` instances.