### PR TITLE
Update for GHC 9.8 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       matrix:
         cabal: ["3.10"]
-        ghc:   ["9.2.8", "9.4.7", "9.6.2"]
+        ghc:   ["9.2.8", "9.4.7", "9.6.3", "9.8.1"]
     env:
       CONFIG: "--enable-tests --enable-benchmarks --flags=dev"
     steps:
       - uses: actions/checkout@v4
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@v2
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}

--- a/megaparsec-tests/megaparsec-tests.cabal
+++ b/megaparsec-tests/megaparsec-tests.cabal
@@ -5,7 +5,7 @@ license:         BSD-2-Clause
 license-file:    LICENSE.md
 maintainer:      Mark Karpov <markkarpov92@gmail.com>
 author:          Megaparsec contributors
-tested-with:     ghc ==9.2.7 ghc ==9.4.4 ghc ==9.6.1
+tested-with:     ghc ==9.2.8 ghc ==9.4.7 ghc ==9.6.3 ghc ==9.8.1
 homepage:        https://github.com/mrkkrp/megaparsec
 bug-reports:     https://github.com/mrkkrp/megaparsec/issues
 synopsis:        Test utilities and the test suite of Megaparsec

--- a/megaparsec-tests/megaparsec-tests.cabal
+++ b/megaparsec-tests/megaparsec-tests.cabal
@@ -26,10 +26,10 @@ library
     build-depends:
         QuickCheck >=2.10 && <2.15,
         base >=4.15 && <5,
-        bytestring >=0.2 && <0.12,
-        containers >=0.5 && <0.7,
-        hspec >=2.0 && <3,
-        hspec-megaparsec >=2.0 && <3,
+        bytestring >=0.2 && <0.13,
+        containers >=0.5 && <0.8,
+        hspec >=2.0 && <3.0,
+        hspec-megaparsec >=2.0 && <3.0,
         megaparsec ==9.5.0,
         mtl >=2.2.2 && <3,
         text >=0.2 && <2.2,
@@ -64,11 +64,11 @@ test-suite tests
     build-depends:
         QuickCheck >=2.10 && <2.15,
         base >=4.15 && <5,
-        bytestring >=0.2 && <0.12,
+        bytestring >=0.2 && <0.13,
         case-insensitive >=1.2 && <1.3,
-        containers >=0.5 && <0.7,
+        containers >=0.5 && <0.8,
         hspec >=2.0 && <3,
-        hspec-megaparsec >=2.0 && <3,
+        hspec-megaparsec >=2.0 && <3.0,
         megaparsec ==9.5.0,
         megaparsec-tests,
         mtl >=2.2.2 && <3,
@@ -84,3 +84,6 @@ test-suite tests
 
     else
         ghc-options: -O2 -Wall
+
+    if impl(ghc >=9.8)
+        ghc-options: -Wno-x-partial

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -57,9 +57,9 @@ library
     default-language: Haskell2010
     build-depends:
         base >=4.15 && <5,
-        bytestring >=0.2 && <0.12,
+        bytestring >=0.2 && <0.13,
         case-insensitive >=1.2 && <1.3,
-        containers >=0.5 && <0.7,
+        containers >=0.5 && <0.8,
         deepseq >=1.3 && <1.6,
         mtl >=2.2.2 && <3,
         parser-combinators >=1.0 && <2,
@@ -73,8 +73,8 @@ library
     else
         ghc-options: -O2 -Wall
 
-    if (flag(dev) && !impl(ghc ==9.6.2))
-        ghc-options: -Wredundant-constraints
+    if impl(ghc >=9.8)
+        ghc-options: -Wno-x-partial
 
 benchmark bench-speed
     type:             exitcode-stdio-1.0
@@ -83,8 +83,8 @@ benchmark bench-speed
     default-language: Haskell2010
     build-depends:
         base >=4.15 && <5,
-        bytestring >=0.2 && <0.12,
-        containers >=0.5 && <0.7,
+        bytestring >=0.2 && <0.13,
+        containers >=0.5 && <0.8,
         criterion >=0.6.2.1 && <1.7,
         deepseq >=1.3 && <1.6,
         megaparsec,
@@ -105,8 +105,8 @@ benchmark bench-memory
     default-language: Haskell2010
     build-depends:
         base >=4.15 && <5,
-        bytestring >=0.2 && <0.12,
-        containers >=0.5 && <0.7,
+        bytestring >=0.2 && <0.13,
+        containers >=0.5 && <0.8,
         deepseq >=1.3 && <1.6,
         megaparsec,
         text >=0.2 && <2.2,

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -9,7 +9,7 @@ author:
     Paolo Martini <paolo@nemail.it>,
     Daan Leijen <daan@microsoft.com>
 
-tested-with:     ghc ==9.2.8 ghc ==9.4.7 ghc ==9.6.2
+tested-with:     ghc ==9.2.8 ghc ==9.4.7 ghc ==9.6.3 ghc ==9.8.1
 homepage:        https://github.com/mrkkrp/megaparsec
 bug-reports:     https://github.com/mrkkrp/megaparsec/issues
 synopsis:        Monadic parser combinators
@@ -68,7 +68,9 @@ library
         transformers >=0.4 && <0.7
 
     if flag(dev)
-        ghc-options: -Wall -Werror -Wpartial-fields -Wunused-packages
+        ghc-options:
+            -Wall -Werror -Wredundant-constraints -Wpartial-fields
+            -Wunused-packages
 
     else
         ghc-options: -O2 -Wall


### PR DESCRIPTION
Otherwise, one might get errors like
```
Error: cabal: Could not resolve dependencies:
[__0] trying: ormolu-0.7.2.0 (user goal)
[__1] trying: th-env-0.1.1 (dependency of ormolu)
[__2] trying: template-haskell-2.21.0.0/installed-54dc (dependency of th-env)
[__3] trying: pretty-1.1.3.6/installed-8ddc (dependency of template-haskell)
[__4] trying: megaparsec-9.5.0 (dependency of ormolu)
[__5] next goal: Cabal-syntax (dependency of ormolu)
[__5] rejecting: Cabal-syntax-3.10.2.0/installed-6d41 (conflict: megaparsec =>
bytestring>=0.2 && <0.12, Cabal-syntax => bytestring==0.12.0.2/installed-66e0)
[__5] rejecting: Cabal-syntax-3.10.1.0 (conflict: pretty =>
deepseq==1.5.0.0/installed-2833, Cabal-syntax => deepseq>=1.3.0.1 && <1.5)
[__5] rejecting: Cabal-syntax-3.8.1.0 (conflict: ormolu => Cabal-syntax>=3.10
&& <3.11)
[__5] skipping: Cabal-syntax-3.6.0.0 (has the same characteristics that caused
the previous version to fail: excluded by constraint '>=3.10 && <3.11' from
'ormolu')
[__5] fail (backjumping, conflict set: Cabal-syntax, megaparsec, ormolu,
pretty)
```
as `bytestring-0.12` (shipped with GHC 9.8) is non-reinstallable when using TH.

 - Allowing `containers-0.7` is not strictly necessary, but it compiles fine.
 - Due to this change in `base-4.19`
   
   > Added `{-# WARNING in "x-partial" #-}` to `Data.List.{head,tail}`.
   
   there are various new warnings with GHC 9.8. We fix these by enabling `-Wno-x-partial`.