### PR TITLE
Formal correction of dep upper bounds: `< x.0` to `< x`

### DIFF
--- a/megaparsec-tests/megaparsec-tests.cabal
+++ b/megaparsec-tests/megaparsec-tests.cabal
@@ -25,13 +25,13 @@ library
     default-language: Haskell2010
     build-depends:
         QuickCheck >=2.10 && <2.15,
-        base >=4.15 && <5.0,
+        base >=4.15 && <5,
         bytestring >=0.2 && <0.12,
         containers >=0.5 && <0.7,
-        hspec >=2.0 && <3.0,
-        hspec-megaparsec >=2.0 && <3.0,
+        hspec >=2.0 && <3,
+        hspec-megaparsec >=2.0 && <3,
         megaparsec ==9.5.0,
-        mtl >=2.2.2 && <3.0,
+        mtl >=2.2.2 && <3,
         text >=0.2 && <2.2,
         transformers >=0.4 && <0.7
 
@@ -63,15 +63,15 @@ test-suite tests
     default-language:   Haskell2010
     build-depends:
         QuickCheck >=2.10 && <2.15,
-        base >=4.15 && <5.0,
+        base >=4.15 && <5,
         bytestring >=0.2 && <0.12,
         case-insensitive >=1.2 && <1.3,
         containers >=0.5 && <0.7,
-        hspec >=2.0 && <3.0,
-        hspec-megaparsec >=2.0 && <3.0,
+        hspec >=2.0 && <3,
+        hspec-megaparsec >=2.0 && <3,
         megaparsec ==9.5.0,
         megaparsec-tests,
-        mtl >=2.2.2 && <3.0,
+        mtl >=2.2.2 && <3,
         scientific >=0.3.1 && <0.4,
         temporary >=1.1 && <1.4,
         text >=0.2 && <2.2,

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -56,13 +56,13 @@ library
 
     default-language: Haskell2010
     build-depends:
-        base >=4.15 && <5.0,
+        base >=4.15 && <5,
         bytestring >=0.2 && <0.12,
         case-insensitive >=1.2 && <1.3,
         containers >=0.5 && <0.7,
         deepseq >=1.3 && <1.6,
-        mtl >=2.2.2 && <3.0,
-        parser-combinators >=1.0 && <2.0,
+        mtl >=2.2.2 && <3,
+        parser-combinators >=1.0 && <2,
         scientific >=0.3.7 && <0.4,
         text >=0.2 && <2.2,
         transformers >=0.4 && <0.7
@@ -82,7 +82,7 @@ benchmark bench-speed
     hs-source-dirs:   bench/speed
     default-language: Haskell2010
     build-depends:
-        base >=4.15 && <5.0,
+        base >=4.15 && <5,
         bytestring >=0.2 && <0.12,
         containers >=0.5 && <0.7,
         criterion >=0.6.2.1 && <1.7,
@@ -104,7 +104,7 @@ benchmark bench-memory
     hs-source-dirs:   bench/memory
     default-language: Haskell2010
     build-depends:
-        base >=4.15 && <5.0,
+        base >=4.15 && <5,
         bytestring >=0.2 && <0.12,
         containers >=0.5 && <0.7,
         deepseq >=1.3 && <1.6,


### PR DESCRIPTION
The versions `5.0` and `5` are not the same.
If you write `base < 5.0`, you accept `base-5` but reject `base-5.0.*`.
This is usually not intended.
The correct format for upper bounds is `< ver` where `ver` has no trailing 0s.
