### PR TITLE
Move `Text.Megaparsec.State` into `exposed-modules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 *Megaparsec follows [SemVer](https://semver.org/).*
 
+## Megaparsec 9.6.1
+
+* Exposed `Text.Megaparsec.State`, so that the new functions (`initialState`
+  and `initialPosState`) can be actually imported from it. [PR
+  549](https://github.com/mrkkrp/megaparsec/pull/549).
+
 ## Megaparsec 9.6.0
 
 * Added the functions `initialState` and `initialPosState` to

--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -46,13 +46,13 @@ library
         Text.Megaparsec.Error.Builder
         Text.Megaparsec.Internal
         Text.Megaparsec.Pos
+        Text.Megaparsec.State
         Text.Megaparsec.Stream
 
     other-modules:
         Text.Megaparsec.Class
         Text.Megaparsec.Common
         Text.Megaparsec.Lexer
-        Text.Megaparsec.State
 
     default-language: Haskell2010
     build-depends:


### PR DESCRIPTION
#539 exported `initialState` and `initialPosState`, and the CHANGELOG for 9.6.0 indicated that these are now available for use.  Unfortunately, they are not, since they were exported from `Text.Megaparsec.State`, which itself is not exported from the package.  This PR simply moves `Text.Megaparsec.State` from `other-modules` to `exported-modules` to allow `initialState` and `initialPosState` to be used as advertised.

If another solution is considered more desirable (*e.g.* re-exporting `initialState` and `initialPosState` from some other module) I'd be happy to modify the PR or open a new one.