### PR TITLE
Expand elem/notElem to allow fusion

### DIFF
--- a/Text/Megaparsec.hs
+++ b/Text/Megaparsec.hs
@@ -516,7 +516,7 @@ oneOf ::
   -- | Collection of matching tokens
   f (Token s) ->
   m (Token s)
-oneOf cs = satisfy (`elem` cs)
+oneOf cs = satisfy (\x -> elem x cs)
 {-# INLINE oneOf #-}
 
 -- | As the dual of 'oneOf', @'noneOf' ts@ succeeds if the current token
@@ -538,7 +538,7 @@ noneOf ::
   -- | Collection of taken we should not match
   f (Token s) ->
   m (Token s)
-noneOf cs = satisfy (`notElem` cs)
+noneOf cs = satisfy (\x -> notElem x cs)
 {-# INLINE noneOf #-}
 
 -- | @'chunk' chk@ only matches the chunk @chk@.

--- a/parsers-bench/ParsersBench/CSV/Attoparsec.hs
+++ b/parsers-bench/ParsersBench/CSV/Attoparsec.hs
@@ -53,5 +53,5 @@ escapedField =
 
 unescapedField :: Parser ByteString
 unescapedField =
-  A.takeWhile (`notElem` (",\"\n\r" :: String))
+  A.takeWhile (\x -> notElem x [',', '\"', '\n', '\r'])
 {-# INLINE unescapedField #-}

--- a/parsers-bench/ParsersBench/CSV/Megaparsec.hs
+++ b/parsers-bench/ParsersBench/CSV/Megaparsec.hs
@@ -52,5 +52,5 @@ unescapedField :: Parser ByteString
 unescapedField =
   takeWhileP
     (Just "unescaped char")
-    (`notElem` [44, 34, 10, 13])
+    (\x -> notElem x [44, 34, 10, 13])
 {-# INLINE unescapedField #-}


### PR DESCRIPTION
GHC doesn't seem to inline or fuse the infix version of `elem/notElem`.  Fully expanding their uses does allow it.

csv benchmarks get faster and `satisfy (\x -> x == '\'' || x == '\"') = oneOf ['\'', '\"']` now holds with regards to performance. Note that `oneOf "'\""` will still be slower, which is why I left the note unchanged.