### PR TITLE
Inline applicative operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Implemented correct handling of wide Unicode characters in error messages.
   To that end, a new module `Text.Megaparsec.Unicode` was introduced. [Issue
   370](https://github.com/mrkkrp/megaparsec/issues/370).
+* Inlined `Applicative` operators `(<*)` and `(*>)`. [PR
+  566](https://github.com/mrkkrp/megaparsec/pull/566).
 
 ## Megaparsec 9.6.1
 

--- a/Text/Megaparsec/Internal.hs
+++ b/Text/Megaparsec/Internal.hs
@@ -174,7 +174,9 @@ instance (Stream s) => Applicative (ParsecT e s m) where
   pure = pPure
   (<*>) = pAp
   p1 *> p2 = p1 `pBind` const p2
+  {-# INLINE (*>) #-}
   p1 <* p2 = do x1 <- p1; void p2; return x1
+  {-# INLINE (<*) #-}
 
 pPure :: (Stream s) => a -> ParsecT e s m a
 pPure x = ParsecT $ \s _ _ eok _ -> eok x s mempty


### PR DESCRIPTION
The applicative operators `*>` and `<*` are not inlined in the generated GHC Core, so I added `INLINE` pragmas to them. As a result, parsing CSV and JSON takes around 40% less time when running the benchmarks on my machine.
