### PR TITLE
chore: fix typo in `mzero` docs

### DIFF
--- a/Text/Megaparsec/Internal.hs
+++ b/Text/Megaparsec/Internal.hs
@@ -331,7 +331,7 @@ pmkParsec k = ParsecT $ \s cok cerr eok eerr ->
 -- __Note__: strictly speaking, this instance is unlawful. The right
 -- identity law does not hold, e.g. in general this is not true:
 --
--- > v >> mzero = mero
+-- > v >> mzero = mzero
 --
 -- However the following holds:
 --


### PR DESCRIPTION
Sorry for bothering with PR just for such small typo, but it really confused me for some time. I had to dig the sources and Hoogle for such function before I finally realized it was a typo.