### PR TITLE
Add `Text.Megaparsec.Error.errorBundlePrettyForGhcPreProcessors`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * `many` and `some` of the `Alternative` instance of `ParsecT` are now more
   efficient, since they use the monadic implementations under the hood.
   [Issue 567](https://github.com/mrkkrp/megaparsec/issues/567).
+* Add `Text.Megaparsec.Error.errorBundlePrettyForGhcPreProcessors`. [PR
+  573](https://github.com/mrkkrp/megaparsec/pull/573).
 
 ## Megaparsec 9.6.1
 


### PR DESCRIPTION
If you use `errorBundlePretty` when writing a [GHC pre-processor](https://downloads.haskell.org/ghc/latest/docs/users_guide/phases.html#pre-processor) then error output does not look pretty:
![before](https://github.com/user-attachments/assets/61beb2ec-58c2-43c0-b3e7-2d60ed874c34)

To address this, this PR adds `errorBundlePrettyForGhcPreProcessors`, which results in:
![after](https://github.com/user-attachments/assets/c4510299-6bec-483c-9301-84149c3c75da)

Details:

1. When a GHC pre-processor fails, then GHC parses source locations and error messages from the pre-processor's output.
2. Multi-line error messages have to be ***indented***, otherwise GHC won't parse them properly.
3. When GHC pretty-prints error message it indents multi-line error messages by ***four spaces***, but it ***does not strip any whitespace*** from parsed error messages before pretty-printing them.

As a consequence, the best you can achieve for a pre-processor is to have multi-line error messages indented by ***five spaces.***  To achieve this you have to produce error messages of the form:

```
src/Foo.hs:23:42: foo
 bar
 baz
```
That is: 
1. The first line of the message has to be on the same same line as the source location separated by exactly ***one space***.
2. Each subsequent line has to be indented by ***one space***.

Note that single-line error message should be of the form:
```
src/Foo.hs:23:42:foo
```
(***no space*** between the last `:` and the error message, otherwise you will end up with two spaces in the pretty-printed output)