### PR TITLE
Fix minor typos in Text.Megaparsec docs

### DIFF
--- a/Text/Megaparsec.hs
+++ b/Text/Megaparsec.hs
@@ -386,8 +386,8 @@ region f m = do
 -- | Register a 'ParseError' for later reporting. This action does not end
 -- parsing and has no effect except for adding the given 'ParseError' to the
 -- collection of “delayed” 'ParseError's which will be taken into
--- consideration at the end of parsing. Only if this collection is empty the
--- parser will succeed. This is the main way to report several parse errors
+-- consideration at the end of parsing. Only if this collection is empty will
+-- the parser succeed. This is the main way to report several parse errors
 -- at once.
 --
 -- @since 8.0.0
@@ -523,7 +523,7 @@ oneOf ::
 oneOf cs = satisfy (\x -> elem x cs)
 {-# INLINE oneOf #-}
 
--- | As the dual of 'oneOf', @'noneOf' ts@ succeeds if the current token
+-- | As the dual of 'oneOf', @'noneOf' ts@ succeeds if the current token is
 -- /not/ in the supplied list of tokens @ts@. Returns the parsed character.
 -- Note that this parser cannot automatically generate the “expected”
 -- component of error message, so usually you should label it manually with
@@ -539,7 +539,7 @@ oneOf cs = satisfy (\x -> elem x cs)
 -- @since 7.0.0
 noneOf ::
   (Foldable f, MonadParsec e s m) =>
-  -- | Collection of taken we should not match
+  -- | Collection of tokens we should not match
   f (Token s) ->
   m (Token s)
 noneOf cs = satisfy (\x -> notElem x cs)

--- a/Text/Megaparsec/Class.hs
+++ b/Text/Megaparsec/Class.hs
@@ -126,7 +126,7 @@ class (Stream s, MonadPlus m) => MonadParsec e s m | m -> e s where
   -- to the point where the next object starts.
   --
   -- Note that if @r@ fails, the original error message is reported as if
-  -- without 'withRecovery'. In no way recovering parser @r@ can influence
+  -- without 'withRecovery'. In no way can the recovering parser @r@ influence
   -- error messages.
   --
   -- @since 4.4.0
@@ -245,7 +245,7 @@ class (Stream s, MonadPlus m) => MonadParsec e s m | m -> e s where
     m (Tokens s)
 
   -- | Extract the specified number of tokens from the input stream and
-  -- return them packed as a chunk of stream. If there is not enough tokens
+  -- return them packed as a chunk of stream. If there are not enough tokens
   -- in the stream, a parse error will be signaled. It's guaranteed that if
   -- the parser succeeds, the requested number of tokens will be returned.
   --


### PR DESCRIPTION
just some things i spotted while i was reading the docs

i didn't bother adding the word "the" in most of the places it would have fit, but there was one place in particular where it made the sentence less ambiguous so i added it there