### PR TITLE
Fix typos

### DIFF
--- a/Text/Megaparsec/Internal.hs
+++ b/Text/Megaparsec/Internal.hs
@@ -440,10 +440,10 @@ pLookAhead p = ParsecT $ \s _ cerr eok eerr ->
 pNotFollowedBy :: (Stream s) => ParsecT e s m a -> ParsecT e s m ()
 pNotFollowedBy p = ParsecT $ \s@(State input o _ _) _ _ eok eerr ->
   let what = maybe EndOfInput (Tokens . nes . fst) (take1_ input)
-      unexpect u = TrivialError o (pure u) E.empty
-      cok' _ _ _ = eerr (unexpect what) s
+      unexpected u = TrivialError o (pure u) E.empty
+      cok' _ _ _ = eerr (unexpected what) s
       cerr' _ _ = eok () s mempty
-      eok' _ _ _ = eerr (unexpect what) s
+      eok' _ _ _ = eerr (unexpected what) s
       eerr' _ _ = eok () s mempty
    in unParser p s cok' cerr' eok' eerr'
 {-# INLINE pNotFollowedBy #-}
@@ -521,14 +521,14 @@ pTokens ::
   ParsecT e s m (Tokens s)
 pTokens f tts = ParsecT $ \s@(State input o pst de) cok _ eok eerr ->
   let pxy = Proxy :: Proxy s
-      unexpect pos' u =
+      unexpected pos' u =
         let us = pure u
             ps = (E.singleton . Tokens . NE.fromList . chunkToTokens pxy) tts
          in TrivialError pos' us ps
       len = chunkLength pxy tts
    in case takeN_ len input of
         Nothing ->
-          eerr (unexpect o EndOfInput) s
+          eerr (unexpected o EndOfInput) s
         Just (tts', input') ->
           if f tts tts'
             then
@@ -538,7 +538,7 @@ pTokens f tts = ParsecT $ \s@(State input o pst de) cok _ eok eerr ->
                     else cok tts' st mempty
             else
               let ps = (Tokens . NE.fromList . chunkToTokens pxy) tts'
-               in eerr (unexpect o ps) (State input o pst de)
+               in eerr (unexpected o ps) (State input o pst de)
 {-# INLINE pTokens #-}
 
 pTakeWhileP ::

--- a/megaparsec-tests/src/Test/Hspec/Megaparsec/AdHoc.hs
+++ b/megaparsec-tests/src/Test/Hspec/Megaparsec/AdHoc.hs
@@ -235,7 +235,7 @@ strSourcePos tabWidth ipos input =
 toChar :: Word8 -> Char
 toChar = chr . fromIntegral
 
--- | Covert a char to byte.
+-- | Convert a char to byte.
 fromChar :: Char -> Maybe Word8
 fromChar x =
   let p = ord x

--- a/megaparsec-tests/tests/Text/Megaparsec/Byte/LexerSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/Byte/LexerSpec.hs
@@ -263,7 +263,7 @@ spec = do
           prs p s `shouldParse` n
           prs' p s `succeedsLeaving` ""
     context "with scientific" $
-      it "parses singed scientific numbers" $
+      it "parses signed scientific numbers" $
         property $ \n -> do
           let p = signed (hidden B.space) scientific
               s = B8.pack $ either show show (n :: Either Integer Double)

--- a/megaparsec-tests/tests/Text/Megaparsec/Char/LexerSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/Char/LexerSpec.hs
@@ -497,7 +497,7 @@ spec = do
           prs p s `shouldParse` n
           prs' p s `succeedsLeaving` ""
     context "with scientific" $
-      it "parses singed scientific numbers" $
+      it "parses signed scientific numbers" $
         property $ \n -> do
           let p = signed (hidden C.space) scientific
               s = either show show (n :: Either Integer Double)

--- a/megaparsec-tests/tests/Text/Megaparsec/UnicodeSpec.hs
+++ b/megaparsec-tests/tests/Text/Megaparsec/UnicodeSpec.hs
@@ -6,7 +6,7 @@ import qualified Text.Megaparsec.Unicode as Unicode
 spec :: Spec
 spec = do
   describe "stringLength" $
-    it "computes correct length in the presense of wide chars" $
+    it "computes correct length in the presence of wide chars" $
       Unicode.stringLength "123 구구 이면" `shouldBe` 13
   describe "charLength" $ do
     it "returns 1 for non-wide chars" $

--- a/megaparsec-tests/tests/Text/MegaparsecSpec.hs
+++ b/megaparsec-tests/tests/Text/MegaparsecSpec.hs
@@ -209,7 +209,7 @@ spec = do
                     s = [c, b]
                 prs p s `shouldFailWith` err 0 (utok c <> etok a <> etok b)
                 prs' p s `failsLeaving` s
-        context "when stream is emtpy" $
+        context "when stream is empty" $
           it "signals correct parse error" $
             property $ \a b -> do
               let p = char a <|> (char b *> char a)
@@ -1162,7 +1162,7 @@ spec = do
           grs p "" (`shouldFailWith` TrivialError 0 us ps)
 
     describe "fancyFailure" $
-      it "singals correct parse error" $
+      it "signals correct parse error" $
         property $ \xs -> do
           let p :: (MonadParsec Void String m) => m ()
               p = void (fancyFailure xs)
@@ -1253,8 +1253,8 @@ spec = do
               p = void (registerFailure us ps)
           grs p "" (`shouldFailWith` TrivialError 0 us ps)
 
-    describe "reisterFancyFailure" $
-      it "singals correct parse error" $
+    describe "registerFancyFailure" $
+      it "signals correct parse error" $
         property $ \xs -> do
           let p :: (MonadParsec Void String m) => m ()
               p = void (registerFancyFailure xs)
@@ -1777,7 +1777,7 @@ spec = do
 
     describe "mkParsec" $
       it "enables defining new primitives" $ do
-        -- This example lifts breakOn from text, although in order to re-use
+        -- This example lifts breakOn from text, although in order to reuse
         -- the machinery that we have here it parses String, hence
         -- conversions. The parser always succeeds.
         let breakOn end = mkParsec $ \s ->


### PR DESCRIPTION
Found via `codespell -L shouldbe,te,abd` and `typos --hidden --format brief`