### PR TITLE
Require base-4.20

### DIFF
--- a/megaparsec.cabal
+++ b/megaparsec.cabal
@@ -58,7 +58,7 @@ library
     default-language: Haskell2010
     build-depends:
         array >=0.5.3 && <0.6,
-        base >=4.15 && <5,
+        base >=4.20 && <5,
         bytestring >=0.2 && <0.13,
         case-insensitive >=1.2 && <1.3,
         containers >=0.5 && <0.9,


### PR DESCRIPTION
Earlier versions of `base` can no longer be used to build `megaparsec-9.8.0` because of the lack of `Prelude.foldl'`.

See https://hackage.haskell.org/package/megaparsec-9.8.0/reports/2 for an example of build failure with `base-4.19`. 

Could you please make a revision for `megaparsec-9.8.0`?